### PR TITLE
fix: Clean up test output by respecting DEBUG environment variable

### DIFF
--- a/node/packages/webpods-cli-tests/src/test-setup.ts
+++ b/node/packages/webpods-cli-tests/src/test-setup.ts
@@ -33,7 +33,10 @@ function createTestJWT(userId: string, email: string): string {
  * Setup before all tests
  */
 export async function setupCliTests(): Promise<void> {
-  console.log("Setting up CLI test environment...");
+  const isDebug = process.env.DEBUG === "true" || process.env.DEBUG === "1";
+  if (isDebug) {
+    console.log("Setting up CLI test environment...");
+  }
 
   // Setup test database with a different name to avoid conflicts
   testDb = new TestDatabase({ dbName: "webpodsdb_cli_test" });
@@ -52,14 +55,19 @@ export async function setupCliTests(): Promise<void> {
 
   testToken = createTestJWT(testUser.userId, testUser.email);
 
-  console.log("CLI test environment ready");
+  if (isDebug) {
+    console.log("CLI test environment ready");
+  }
 }
 
 /**
  * Cleanup after all tests
  */
 export async function cleanupCliTests(): Promise<void> {
-  console.log("Cleaning up CLI test environment...");
+  const isDebug = process.env.DEBUG === "true" || process.env.DEBUG === "1";
+  if (isDebug) {
+    console.log("Cleaning up CLI test environment...");
+  }
 
   if (testServer) {
     await testServer.stop();
@@ -69,7 +77,9 @@ export async function cleanupCliTests(): Promise<void> {
     await testDb.cleanup();
   }
 
-  console.log("CLI test environment cleaned up");
+  if (isDebug) {
+    console.log("CLI test environment cleaned up");
+  }
 }
 
 /**

--- a/node/packages/webpods-cli-tests/test-pod-1756975293652-backup-1756975293724.json
+++ b/node/packages/webpods-cli-tests/test-pod-1756975293652-backup-1756975293724.json
@@ -1,0 +1,148 @@
+{
+  "pod": "test-pod-1756975293652",
+  "exported_at": "2025-09-04T08:41:33.743Z",
+  "version": "1.0",
+  "streams": {
+    "blog/posts": {
+      "records": [
+        {
+          "index": 0,
+          "content": {
+            "stream": "blog/posts",
+            "index": 0,
+            "data": "Content for blog/posts record 0"
+          },
+          "contentType": "application/json",
+          "name": "record-0",
+          "hash": "sha256:hash-blog/posts-0",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.656Z"
+        },
+        {
+          "index": 1,
+          "content": {
+            "stream": "blog/posts",
+            "index": 1,
+            "data": "Content for blog/posts record 1"
+          },
+          "contentType": "application/json",
+          "name": "record-1",
+          "hash": "sha256:hash-blog/posts-1",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.659Z"
+        },
+        {
+          "index": 2,
+          "content": {
+            "stream": "blog/posts",
+            "index": 2,
+            "data": "Content for blog/posts record 2"
+          },
+          "contentType": "application/json",
+          "name": "record-2",
+          "hash": "sha256:hash-blog/posts-2",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.661Z"
+        }
+      ],
+      "total": 3
+    },
+    "private/notes": {
+      "records": [
+        {
+          "index": 0,
+          "content": {
+            "stream": "private/notes",
+            "index": 0,
+            "data": "Content for private/notes record 0"
+          },
+          "contentType": "application/json",
+          "name": "record-0",
+          "hash": "sha256:hash-private/notes-0",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.664Z"
+        },
+        {
+          "index": 1,
+          "content": {
+            "stream": "private/notes",
+            "index": 1,
+            "data": "Content for private/notes record 1"
+          },
+          "contentType": "application/json",
+          "name": "record-1",
+          "hash": "sha256:hash-private/notes-1",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.666Z"
+        },
+        {
+          "index": 2,
+          "content": {
+            "stream": "private/notes",
+            "index": 2,
+            "data": "Content for private/notes record 2"
+          },
+          "contentType": "application/json",
+          "name": "record-2",
+          "hash": "sha256:hash-private/notes-2",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.668Z"
+        }
+      ],
+      "total": 3
+    },
+    "data/users": {
+      "records": [
+        {
+          "index": 0,
+          "content": {
+            "stream": "data/users",
+            "index": 0,
+            "data": "Content for data/users record 0"
+          },
+          "contentType": "application/json",
+          "name": "record-0",
+          "hash": "sha256:hash-data/users-0",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.672Z"
+        },
+        {
+          "index": 1,
+          "content": {
+            "stream": "data/users",
+            "index": 1,
+            "data": "Content for data/users record 1"
+          },
+          "contentType": "application/json",
+          "name": "record-1",
+          "hash": "sha256:hash-data/users-1",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.674Z"
+        },
+        {
+          "index": 2,
+          "content": {
+            "stream": "data/users",
+            "index": 2,
+            "data": "Content for data/users record 2"
+          },
+          "contentType": "application/json",
+          "name": "record-2",
+          "hash": "sha256:hash-data/users-2",
+          "previousHash": null,
+          "author": "93e1fd90-febd-44e7-a982-5599243ece96",
+          "timestamp": "2025-09-04T08:41:33.676Z"
+        }
+      ],
+      "total": 3
+    }
+  }
+}

--- a/node/packages/webpods-cli-tests/test-pod-1756977066674-backup-1756977066746.json
+++ b/node/packages/webpods-cli-tests/test-pod-1756977066674-backup-1756977066746.json
@@ -1,0 +1,148 @@
+{
+  "pod": "test-pod-1756977066674",
+  "exported_at": "2025-09-04T09:11:06.765Z",
+  "version": "1.0",
+  "streams": {
+    "blog/posts": {
+      "records": [
+        {
+          "index": 0,
+          "content": {
+            "stream": "blog/posts",
+            "index": 0,
+            "data": "Content for blog/posts record 0"
+          },
+          "contentType": "application/json",
+          "name": "record-0",
+          "hash": "sha256:hash-blog/posts-0",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.678Z"
+        },
+        {
+          "index": 1,
+          "content": {
+            "stream": "blog/posts",
+            "index": 1,
+            "data": "Content for blog/posts record 1"
+          },
+          "contentType": "application/json",
+          "name": "record-1",
+          "hash": "sha256:hash-blog/posts-1",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.680Z"
+        },
+        {
+          "index": 2,
+          "content": {
+            "stream": "blog/posts",
+            "index": 2,
+            "data": "Content for blog/posts record 2"
+          },
+          "contentType": "application/json",
+          "name": "record-2",
+          "hash": "sha256:hash-blog/posts-2",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.682Z"
+        }
+      ],
+      "total": 3
+    },
+    "private/notes": {
+      "records": [
+        {
+          "index": 0,
+          "content": {
+            "stream": "private/notes",
+            "index": 0,
+            "data": "Content for private/notes record 0"
+          },
+          "contentType": "application/json",
+          "name": "record-0",
+          "hash": "sha256:hash-private/notes-0",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.686Z"
+        },
+        {
+          "index": 1,
+          "content": {
+            "stream": "private/notes",
+            "index": 1,
+            "data": "Content for private/notes record 1"
+          },
+          "contentType": "application/json",
+          "name": "record-1",
+          "hash": "sha256:hash-private/notes-1",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.688Z"
+        },
+        {
+          "index": 2,
+          "content": {
+            "stream": "private/notes",
+            "index": 2,
+            "data": "Content for private/notes record 2"
+          },
+          "contentType": "application/json",
+          "name": "record-2",
+          "hash": "sha256:hash-private/notes-2",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.690Z"
+        }
+      ],
+      "total": 3
+    },
+    "data/users": {
+      "records": [
+        {
+          "index": 0,
+          "content": {
+            "stream": "data/users",
+            "index": 0,
+            "data": "Content for data/users record 0"
+          },
+          "contentType": "application/json",
+          "name": "record-0",
+          "hash": "sha256:hash-data/users-0",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.694Z"
+        },
+        {
+          "index": 1,
+          "content": {
+            "stream": "data/users",
+            "index": 1,
+            "data": "Content for data/users record 1"
+          },
+          "contentType": "application/json",
+          "name": "record-1",
+          "hash": "sha256:hash-data/users-1",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.696Z"
+        },
+        {
+          "index": 2,
+          "content": {
+            "stream": "data/users",
+            "index": 2,
+            "data": "Content for data/users record 2"
+          },
+          "contentType": "application/json",
+          "name": "record-2",
+          "hash": "sha256:hash-data/users-2",
+          "previousHash": null,
+          "author": "509e64df-3ee4-4f5c-a910-08396d9b924e",
+          "timestamp": "2025-09-04T09:11:06.698Z"
+        }
+      ],
+      "total": 3
+    }
+  }
+}

--- a/node/packages/webpods-test-utils/src/index.ts
+++ b/node/packages/webpods-test-utils/src/index.ts
@@ -2,7 +2,7 @@
 export { TestDatabase } from "./utils/test-db.js";
 export { TestServer } from "./utils/test-server.js";
 export { TestHttpClient } from "./utils/test-http-client.js";
-export { testLogger, consoleLogger } from "./utils/test-logger.js";
+export { testLogger, consoleLogger, silentLogger } from "./utils/test-logger.js";
 export type { Logger } from "./utils/test-logger.js";
 export { createMockOAuthProvider } from "./utils/mock-oauth-provider.js";
 export type {

--- a/node/packages/webpods-test-utils/src/utils/test-db.ts
+++ b/node/packages/webpods-test-utils/src/utils/test-db.ts
@@ -3,7 +3,7 @@ import knex from "knex";
 import pgPromise from "pg-promise";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { Logger, consoleLogger } from "./test-logger.js";
+import { Logger, testLogger } from "./test-logger.js";
 
 const pgp = pgPromise();
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -32,7 +32,7 @@ export class TestDatabase {
         config.password || process.env.WEBPODS_DB_PASSWORD || "postgres",
       logger: config.logger,
     };
-    this.logger = config.logger || consoleLogger;
+    this.logger = config.logger || testLogger;
   }
 
   public async setup(): Promise<void> {

--- a/node/packages/webpods-test-utils/src/utils/test-logger.ts
+++ b/node/packages/webpods-test-utils/src/utils/test-logger.ts
@@ -23,9 +23,15 @@ export const consoleLogger: Logger = {
 };
 
 // Silent logger for tests
-export const testLogger: Logger = {
+export const silentLogger: Logger = {
   debug: () => {},
   info: () => {},
   warn: () => {},
   error: () => {},
 };
+
+// Logger that respects DEBUG environment variable
+// Only shows output when DEBUG=true or DEBUG=1
+export const testLogger: Logger = process.env.DEBUG === "true" || process.env.DEBUG === "1" 
+  ? consoleLogger 
+  : silentLogger;


### PR DESCRIPTION
- Modified test-logger to only show logs when DEBUG=true or DEBUG=1
- Updated TestDatabase to use testLogger instead of consoleLogger by default
- Updated CLI test setup to conditionally log based on DEBUG flag
- Exported silentLogger for direct use when needed

Tests now run with clean output by default, making CI/CD logs more readable. To see test setup logs, run tests with DEBUG=true.