### PR TITLE
feat: Add recursive stream query support with CLI integration

### DIFF
--- a/node/packages/webpods-cli-tests/src/tests/recursive-records.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/recursive-records.test.ts
@@ -1,0 +1,257 @@
+/**
+ * CLI Recursive Records Tests
+ */
+
+import { expect } from "chai";
+import { CliTestHelper } from "../cli-test-helpers.js";
+import {
+  setupCliTests,
+  cleanupCliTests,
+  resetCliTestDb,
+  testToken,
+  testUser,
+  testDb,
+} from "../test-setup.js";
+
+describe("CLI Recursive Records", function () {
+  this.timeout(30000);
+
+  let cli: CliTestHelper;
+  let testPodName: string;
+
+  before(async () => {
+    await setupCliTests();
+    cli = new CliTestHelper();
+    await cli.setup();
+  });
+
+  after(async () => {
+    await cli.cleanup();
+    await cleanupCliTests();
+  });
+
+  beforeEach(async () => {
+    await resetCliTestDb();
+
+    // Create a test pod directly in database
+    testPodName = `test-recursive-${Date.now()}`;
+
+    await testDb
+      .getDb()
+      .none("INSERT INTO pod (name, created_at) VALUES ($(name), NOW())", {
+        name: testPodName,
+      });
+  });
+
+  describe("record list --recursive", () => {
+    beforeEach(async () => {
+      const db = testDb.getDb();
+
+      // Create hierarchical streams
+      const streams = ["api", "api/v1", "api/v1/users", "api/v2", "other"];
+
+      for (const streamName of streams) {
+        await db.none(
+          `INSERT INTO stream (pod_name, name, user_id, access_permission, created_at) 
+           VALUES ($(podName), $(streamName), $(userId), 'public', NOW())`,
+          {
+            podName: testPodName,
+            streamName,
+            userId: testUser.userId,
+          },
+        );
+      }
+
+      // Add records to each stream
+      const records = [
+        { stream: "api", name: "record1", content: '{"data": "api root"}' },
+        { stream: "api/v1", name: "record1", content: '{"data": "api v1"}' },
+        {
+          stream: "api/v1/users",
+          name: "record1",
+          content: '{"data": "api v1 users"}',
+        },
+        { stream: "api/v2", name: "record1", content: '{"data": "api v2"}' },
+        { stream: "other", name: "record1", content: '{"data": "other"}' },
+      ];
+
+      for (const record of records) {
+        await db.none(
+          `INSERT INTO record (pod_name, stream_name, index, name, content, content_type, hash, user_id, created_at)
+           VALUES ($(podName), $(streamName), 0, $(name), $(content), 'application/json', 
+                   'sha256:' || encode(sha256($(content)::bytea), 'hex'), $(userId), NOW())`,
+          {
+            podName: testPodName,
+            streamName: record.stream,
+            name: record.name,
+            content: record.content,
+            userId: testUser.userId,
+          },
+        );
+      }
+    });
+
+    it("should list records recursively with --recursive flag", async () => {
+      const result = await cli.exec(
+        [
+          "record",
+          "list",
+          testPodName,
+          "api",
+          "--recursive",
+          "--format",
+          "json",
+        ],
+        {
+          token: testToken,
+        },
+      );
+
+      expect(result.exitCode).to.equal(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.records).to.have.lengthOf(4);
+
+      const recordData = output.records.map((r: any) => r.content.data);
+      expect(recordData).to.include.members([
+        "api root",
+        "api v1",
+        "api v1 users",
+        "api v2",
+      ]);
+      expect(recordData).to.not.include("other");
+    });
+
+    it("should list only nested streams without exact match", async () => {
+      const result = await cli.exec(
+        [
+          "record",
+          "list",
+          testPodName,
+          "api/v1",
+          "--recursive",
+          "--format",
+          "json",
+        ],
+        {
+          token: testToken,
+        },
+      );
+
+      expect(result.exitCode).to.equal(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.records).to.have.lengthOf(2);
+
+      const recordData = output.records.map((r: any) => r.content.data);
+      expect(recordData).to.include.members(["api v1", "api v1 users"]);
+      expect(recordData).to.not.include("api root");
+      expect(recordData).to.not.include("api v2");
+    });
+
+    it("should reject --recursive with --unique", async () => {
+      const result = await cli.exec(
+        ["record", "list", testPodName, "api", "--recursive", "--unique"],
+        {
+          token: testToken,
+        },
+      );
+
+      expect(result.exitCode).to.not.equal(0);
+      expect(result.stderr).to.include(
+        "Cannot use --recursive and --unique together",
+      );
+    });
+
+    it("should work with pagination parameters", async () => {
+      // Add more records to test pagination
+      const db = testDb.getDb();
+      for (let i = 2; i <= 5; i++) {
+        await db.none(
+          `INSERT INTO record (pod_name, stream_name, index, name, content, content_type, hash, user_id, created_at)
+           VALUES ($(podName), $(streamName), $(index), $(name), $(content), 'application/json', 
+                   'sha256:' || encode(sha256($(content)::bytea), 'hex'), $(userId), NOW())`,
+          {
+            podName: testPodName,
+            streamName: "api",
+            index: i - 1,
+            name: `record${i}`,
+            content: JSON.stringify({ data: `api root ${i}` }),
+            userId: testUser.userId,
+          },
+        );
+      }
+
+      const result = await cli.exec(
+        [
+          "record",
+          "list",
+          testPodName,
+          "api",
+          "--recursive",
+          "--limit",
+          "3",
+          "--format",
+          "json",
+        ],
+        {
+          token: testToken,
+        },
+      );
+
+      expect(result.exitCode).to.equal(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.records).to.have.lengthOf(3);
+      expect(output.hasMore).to.be.true;
+    });
+
+    it("should handle non-existent stream with recursive", async () => {
+      const result = await cli.exec(
+        [
+          "record",
+          "list",
+          testPodName,
+          "nonexistent",
+          "--recursive",
+          "--format",
+          "json",
+        ],
+        {
+          token: testToken,
+        },
+      );
+
+      expect(result.exitCode).to.equal(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.records).to.have.lengthOf(0);
+      expect(output.total).to.equal(0);
+      expect(output.hasMore).to.be.false;
+    });
+
+    it("should work with negative after parameter", async () => {
+      const result = await cli.exec(
+        [
+          "record",
+          "list",
+          testPodName,
+          "api",
+          "--recursive",
+          "--after",
+          "-2",
+          "--format",
+          "json",
+        ],
+        {
+          token: testToken,
+        },
+      );
+
+      expect(result.exitCode).to.equal(0);
+
+      const output = JSON.parse(result.stdout);
+      expect(output.records).to.have.lengthOf(2);
+    });
+  });
+});

--- a/node/packages/webpods-cli/src/commands/records/records.ts
+++ b/node/packages/webpods-cli/src/commands/records/records.ts
@@ -302,6 +302,7 @@ export async function list(options: {
   limit?: number;
   after?: number;
   unique?: boolean;
+  recursive?: boolean;
   token?: string;
   server?: string;
   profile?: string;
@@ -317,10 +318,18 @@ export async function list(options: {
       limit: options.limit,
       after: options.after,
       unique: options.unique,
+      recursive: options.recursive,
     });
 
     if (!options.pod || !options.stream) {
       output.error("Pod and stream are required for listing records.");
+      process.exit(1);
+    }
+
+    // Check for incompatible options
+    if (options.recursive && options.unique) {
+      output.error("Cannot use --recursive and --unique together.");
+      logger.error("Incompatible options: recursive and unique");
       process.exit(1);
     }
 
@@ -337,6 +346,10 @@ export async function list(options: {
 
     if (options.unique) {
       params.set("unique", "true");
+    }
+
+    if (options.recursive) {
+      params.set("recursive", "true");
     }
 
     if (params.toString()) {
@@ -369,7 +382,11 @@ export async function list(options: {
     });
 
     if (response.records.length === 0) {
-      output.print("No records found in this stream.");
+      if (format === "json") {
+        output.print(JSON.stringify(response, null, 2));
+      } else {
+        output.print("No records found in this stream.");
+      }
       return;
     }
 

--- a/node/packages/webpods-cli/src/index.ts
+++ b/node/packages/webpods-cli/src/index.ts
@@ -19,7 +19,11 @@ import {
   infoPod,
 } from "./commands/pods/index.js";
 import { write, read, list } from "./commands/records/index.js";
-import { streams, deleteStream, createStream } from "./commands/streams/index.js";
+import {
+  streams,
+  deleteStream,
+  createStream,
+} from "./commands/streams/index.js";
 import { permissions } from "./commands/permissions/index.js";
 import {
   oauthRegister,
@@ -369,6 +373,10 @@ export async function main() {
                 .option("unique", {
                   type: "boolean",
                   describe: "Show only unique named records",
+                })
+                .option("recursive", {
+                  type: "boolean",
+                  describe: "Include records from nested streams",
                 })
                 .option("token", {
                   type: "string",

--- a/node/packages/webpods-integration-tests/src/tests/recursive-streams.test.ts
+++ b/node/packages/webpods-integration-tests/src/tests/recursive-streams.test.ts
@@ -1,0 +1,240 @@
+// Recursive stream queries tests for WebPods
+import { expect } from "chai";
+import {
+  TestHttpClient,
+  createTestUser,
+  createTestPod,
+} from "webpods-test-utils";
+import { testDb } from "../test-setup.js";
+
+describe("Recursive Stream Queries", () => {
+  let client: TestHttpClient;
+  let userId: string;
+  let authToken: string;
+  const testPodId = "test-recursive-pod";
+  const baseUrl = `http://${testPodId}.localhost:3000`;
+
+  beforeEach(async () => {
+    client = new TestHttpClient("http://localhost:3000");
+    // Create a test user and auth token
+    const db = testDb.getDb();
+    const user = await createTestUser(db, {
+      provider: "test-auth-provider-1",
+      providerId: "recursive-test-user",
+      email: "recursive@example.com",
+      name: "Recursive Test User",
+    });
+
+    userId = user.userId;
+
+    // Create the test pod
+    await createTestPod(db, testPodId, userId);
+
+    // Get OAuth token via Hydra
+    authToken = await client.authenticateViaOAuth(userId, [testPodId]);
+
+    client.setBaseUrl(baseUrl);
+    client.setAuthToken(authToken);
+  });
+
+  describe("GET /{stream}?recursive=true", () => {
+    it("should return records from exact stream and nested streams", async () => {
+      // Create streams with hierarchical structure
+      // /api
+      // /api/v1
+      // /api/v1/users
+      // /api/v2
+      // /other
+
+      // Write records to different streams
+      await client.post("/api/record1", { data: "api root record" });
+      await client.post("/api/v1/record1", { data: "api v1 record" });
+      await client.post("/api/v1/users/record1", {
+        data: "api v1 users record",
+      });
+      await client.post("/api/v2/record1", { data: "api v2 record" });
+      await client.post("/other/record1", { data: "other record" });
+
+      // Query /api recursively - should get all /api* records
+      const response = await client.get("/api?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(4);
+      expect(response.data.total).to.equal(4);
+
+      // Verify we got the right records
+      const recordData = response.data.records.map((r: any) => r.content.data);
+      expect(recordData).to.include.members([
+        "api root record",
+        "api v1 record",
+        "api v1 users record",
+        "api v2 record",
+      ]);
+      expect(recordData).to.not.include("other record");
+    });
+
+    it("should return records from nested path /api/v1 recursively", async () => {
+      // Create the same structure as above
+      await client.post("/api/record1", { data: "api root record" });
+      await client.post("/api/v1/record1", { data: "api v1 record" });
+      await client.post("/api/v1/users/record1", {
+        data: "api v1 users record",
+      });
+      await client.post("/api/v2/record1", { data: "api v2 record" });
+
+      // Query /api/v1 recursively - should only get /api/v1 and /api/v1/users
+      const response = await client.get("/api/v1?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(2);
+      expect(response.data.total).to.equal(2);
+
+      const recordData = response.data.records.map((r: any) => r.content.data);
+      expect(recordData).to.include.members([
+        "api v1 record",
+        "api v1 users record",
+      ]);
+      expect(recordData).to.not.include("api root record");
+      expect(recordData).to.not.include("api v2 record");
+    });
+
+    it("should return empty when no matching streams exist", async () => {
+      const response = await client.get("/nonexistent?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(0);
+      expect(response.data.total).to.equal(0);
+      expect(response.data.hasMore).to.be.false;
+    });
+
+    it("should respect pagination with recursive queries", async () => {
+      // Create multiple records
+      for (let i = 0; i < 5; i++) {
+        await client.post(`/test/record${i}`, { data: `test record ${i}` });
+      }
+
+      for (let i = 0; i < 5; i++) {
+        await client.post(`/test/nested/record${i}`, {
+          data: `nested record ${i}`,
+        });
+      }
+
+      // Query with limit
+      const response = await client.get("/test?recursive=true&limit=3");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(3);
+      expect(response.data.total).to.equal(10);
+      expect(response.data.hasMore).to.be.true;
+    });
+
+    it("should work with negative after parameter", async () => {
+      // Create records
+      for (let i = 0; i < 3; i++) {
+        await client.post(`/data/record${i}`, { data: `data record ${i}` });
+      }
+
+      for (let i = 0; i < 2; i++) {
+        await client.post(`/data/sub/record${i}`, { data: `sub record ${i}` });
+      }
+
+      // Get last 3 records
+      const response = await client.get("/data?recursive=true&after=-3");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(3);
+      expect(response.data.total).to.equal(5);
+    });
+
+    it("should respect stream permissions when querying recursively", async () => {
+      // Create public stream
+      await client.post("/public/record1", { data: "public record" });
+
+      // Create private stream
+      await client.post("/public/private/record1?access=private", {
+        data: "private record",
+      });
+
+      // Query without auth - should only see public
+      const unauthClient = new TestHttpClient(baseUrl);
+      const response = await unauthClient.get("/public?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(1);
+      const recordData = response.data.records.map((r: any) => r.content.data);
+      expect(recordData).to.include("public record");
+      expect(recordData).to.not.include("private record");
+
+      // Query with auth - should see both
+      const authResponse = await client.get("/public?recursive=true");
+      expect(authResponse.status).to.equal(200);
+      expect(authResponse.data.records).to.have.lengthOf(2);
+      const authRecordData = authResponse.data.records.map(
+        (r: any) => r.content.data,
+      );
+      expect(authRecordData).to.include.members([
+        "public record",
+        "private record",
+      ]);
+    });
+
+    it("should not match sibling streams with similar names", async () => {
+      // Create streams that should not match
+      await client.post("/api/record1", { data: "api record" });
+      await client.post("/api2/record1", { data: "api2 record" });
+      await client.post("/api_other/record1", { data: "api_other record" });
+
+      // Query /api recursively
+      const response = await client.get("/api?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(1);
+      const recordData = response.data.records.map((r: any) => r.content.data);
+      expect(recordData).to.include("api record");
+      expect(recordData).to.not.include("api2 record");
+      expect(recordData).to.not.include("api_other record");
+    });
+
+    it("should fail when combining recursive with unique parameter", async () => {
+      const response = await client.get("/test?recursive=true&unique=true");
+      expect(response.status).to.equal(400);
+      expect(response.data.error.code).to.equal("INVALID_PARAMETERS");
+      expect(response.data.error.message).to.include(
+        "Cannot use 'unique' and 'recursive' parameters together",
+      );
+    });
+
+    it("should handle deep nesting correctly", async () => {
+      // Create deeply nested structure
+      await client.post("/a/record1", { data: "level 1" });
+      await client.post("/a/b/record1", { data: "level 2" });
+      await client.post("/a/b/c/record1", { data: "level 3" });
+      await client.post("/a/b/c/d/record1", { data: "level 4" });
+
+      // Query from middle level
+      const response = await client.get("/a/b?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(3);
+      const recordData = response.data.records.map((r: any) => r.content.data);
+      expect(recordData).to.include.members(["level 2", "level 3", "level 4"]);
+      expect(recordData).to.not.include("level 1");
+    });
+
+    it("should sort records by creation time across streams", async () => {
+      // Create records with small delays to ensure different timestamps
+      await client.post("/time/stream1/first", { data: "first" });
+
+      // Small delay
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await client.post("/time/stream2/second", { data: "second" });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await client.post("/time/third", { data: "third" });
+
+      const response = await client.get("/time?recursive=true");
+      expect(response.status).to.equal(200);
+      expect(response.data.records).to.have.lengthOf(3);
+
+      // Verify chronological order
+      const recordData = response.data.records.map((r: any) => r.content.data);
+      expect(recordData[0]).to.equal("first");
+      expect(recordData[1]).to.equal("second");
+      expect(recordData[2]).to.equal("third");
+    });
+  });
+});

--- a/node/packages/webpods/src/domain/records/list-records-recursive.ts
+++ b/node/packages/webpods/src/domain/records/list-records-recursive.ts
@@ -1,0 +1,175 @@
+/**
+ * List records from multiple streams recursively
+ */
+
+import { DataContext } from "../data-context.js";
+import { Result, success, failure } from "../../utils/result.js";
+import { RecordDbRow } from "../../db-types.js";
+import { StreamRecord } from "../../types.js";
+import { createLogger } from "../../logger.js";
+import { getStreamsWithPrefix } from "../streams/get-streams-with-prefix.js";
+import { canRead } from "../permissions/can-read.js";
+
+const logger = createLogger("webpods:domain:records");
+
+/**
+ * Map database row to domain type
+ */
+function mapRecordFromDb(row: RecordDbRow): StreamRecord {
+  return {
+    id: row.id ? parseInt(row.id) : 0,
+    podName: row.pod_name,
+    streamName: row.stream_name,
+    index: row.index,
+    content: row.content,
+    contentType: row.content_type,
+    name: row.name || "",
+    hash: row.hash,
+    previousHash: row.previous_hash || null,
+    userId: row.user_id,
+    metadata: undefined,
+    createdAt:
+      typeof row.created_at === "string"
+        ? new Date(row.created_at)
+        : row.created_at,
+  };
+}
+
+export async function listRecordsRecursive(
+  ctx: DataContext,
+  podName: string,
+  streamName: string,
+  userId: string | null,
+  limit: number = 100,
+  after?: number,
+): Promise<
+  Result<{ records: StreamRecord[]; total: number; hasMore: boolean }>
+> {
+  try {
+    // Step 1: Get all matching streams
+    const streamsResult = await getStreamsWithPrefix(ctx, podName, streamName);
+
+    if (!streamsResult.success) {
+      return failure(streamsResult.error);
+    }
+
+    const streams = streamsResult.data;
+
+    if (streams.length === 0) {
+      // No streams found
+      return success({
+        records: [],
+        total: 0,
+        hasMore: false,
+      });
+    }
+
+    // Step 2: Check permissions for each stream
+    const readableStreams = [];
+    for (const stream of streams) {
+      const canReadResult = await canRead(ctx, stream, userId);
+      if (canReadResult) {
+        readableStreams.push(stream);
+      }
+    }
+
+    if (readableStreams.length === 0) {
+      // No readable streams
+      return success({
+        records: [],
+        total: 0,
+        hasMore: false,
+      });
+    }
+
+    // Step 3: Fetch records from each readable stream
+    const allRecords: RecordDbRow[] = [];
+    let totalCount = 0;
+
+    for (const stream of readableStreams) {
+      // Get records from this stream
+      const records = await ctx.db.manyOrNone<RecordDbRow>(
+        `SELECT * FROM record 
+         WHERE pod_name = $(pod_name) 
+           AND stream_name = $(stream_name)
+         ORDER BY index ASC`,
+        { pod_name: podName, stream_name: stream.name },
+      );
+
+      allRecords.push(...records);
+
+      // Get count for this stream
+      const countResult = await ctx.db.one<{ count: string }>(
+        `SELECT COUNT(*) as count FROM record 
+         WHERE pod_name = $(pod_name) 
+           AND stream_name = $(stream_name)`,
+        { pod_name: podName, stream_name: stream.name },
+      );
+
+      totalCount += parseInt(countResult.count);
+    }
+
+    // Step 4: Sort all records by creation time
+    allRecords.sort((a, b) => {
+      const dateA =
+        typeof a.created_at === "string"
+          ? new Date(a.created_at).getTime()
+          : a.created_at.getTime();
+      const dateB =
+        typeof b.created_at === "string"
+          ? new Date(b.created_at).getTime()
+          : b.created_at.getTime();
+      return dateA - dateB;
+    });
+
+    // Step 5: Apply pagination
+    let paginatedRecords = allRecords;
+    let hasMore = false;
+
+    // Handle negative 'after' parameter
+    let actualAfter = after;
+    if (after !== undefined && after < 0) {
+      // after=-3 means "get the last 3 records"
+      actualAfter = totalCount + after - 1;
+      if (actualAfter < 0) {
+        actualAfter = -1; // Get all from start
+      }
+    }
+
+    // Apply 'after' filter
+    if (actualAfter !== undefined && actualAfter >= 0) {
+      // Skip records up to 'after' index
+      paginatedRecords = paginatedRecords.slice(actualAfter + 1);
+    }
+
+    // Apply limit
+    if (paginatedRecords.length > limit) {
+      hasMore = true;
+      paginatedRecords = paginatedRecords.slice(0, limit);
+    }
+
+    logger.debug("Listed records recursively", {
+      podName,
+      streamName,
+      streamCount: readableStreams.length,
+      totalRecords: totalCount,
+      returnedRecords: paginatedRecords.length,
+      hasMore,
+    });
+
+    return success({
+      records: paginatedRecords.map(mapRecordFromDb),
+      total: totalCount,
+      hasMore,
+    });
+  } catch (error: unknown) {
+    logger.error("Failed to list records recursively", {
+      error,
+      podName,
+      streamName,
+      limit,
+      after,
+    });
+    return failure(new Error("Failed to list records recursively"));
+  }
+}

--- a/node/packages/webpods/src/domain/streams/get-streams-with-prefix.ts
+++ b/node/packages/webpods/src/domain/streams/get-streams-with-prefix.ts
@@ -1,0 +1,85 @@
+/**
+ * Get all streams matching a prefix pattern
+ */
+
+import { DataContext } from "../data-context.js";
+import { Result, success, failure } from "../../utils/result.js";
+import { createError } from "../../utils/errors.js";
+import { StreamDbRow } from "../../db-types.js";
+import { Stream } from "../../types.js";
+import { createLogger } from "../../logger.js";
+
+const logger = createLogger("webpods:domain:streams");
+
+/**
+ * Map database row to domain type
+ */
+function mapStreamFromDb(row: StreamDbRow): Stream {
+  return {
+    podName: row.pod_name,
+    name: row.name,
+    userId: row.user_id,
+    accessPermission: row.access_permission,
+    metadata: row.metadata,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at || row.created_at,
+  };
+}
+
+/**
+ * Get streams that match exactly or start with a prefix
+ * For streamName "a/b", this will match:
+ * - "a/b" (exact match)
+ * - "a/b/c", "a/b/d", etc. (starts with "a/b/")
+ */
+export async function getStreamsWithPrefix(
+  ctx: DataContext,
+  podName: string,
+  streamName: string,
+): Promise<Result<Stream[]>> {
+  try {
+    // First query: exact match
+    const exactStream = await ctx.db.oneOrNone<StreamDbRow>(
+      `SELECT * FROM stream 
+       WHERE pod_name = $(pod_name) 
+         AND name = $(stream_name)`,
+      { pod_name: podName, stream_name: streamName },
+    );
+
+    // Second query: streams starting with prefix
+    const nestedStreams = await ctx.db.manyOrNone<StreamDbRow>(
+      `SELECT * FROM stream 
+       WHERE pod_name = $(pod_name) 
+         AND name LIKE $(prefix)`,
+      { pod_name: podName, prefix: `${streamName}/%` },
+    );
+
+    const allStreams: StreamDbRow[] = [];
+
+    // Add exact match if it exists
+    if (exactStream) {
+      allStreams.push(exactStream);
+    }
+
+    // Add nested streams
+    allStreams.push(...nestedStreams);
+
+    logger.debug("Found streams with prefix", {
+      podName,
+      streamName,
+      count: allStreams.length,
+      streams: allStreams.map((s) => s.name),
+    });
+
+    return success(allStreams.map(mapStreamFromDb));
+  } catch (error: unknown) {
+    logger.error("Failed to get streams with prefix", {
+      error,
+      podName,
+      streamName,
+    });
+    return failure(
+      createError("DATABASE_ERROR", "Failed to fetch streams with prefix"),
+    );
+  }
+}

--- a/node/packages/webpods/src/routes/pods.ts
+++ b/node/packages/webpods/src/routes/pods.ts
@@ -44,6 +44,7 @@ import { getRecord } from "../domain/records/get-record.js";
 import { getRecordRange } from "../domain/records/get-record-range.js";
 import { listRecords } from "../domain/records/list-records.js";
 import { listUniqueRecords } from "../domain/records/list-unique-records.js";
+import { listRecordsRecursive } from "../domain/records/list-records-recursive.js";
 import { recordToResponse } from "../domain/records/record-to-response.js";
 import { canRead } from "../domain/permissions/can-read.js";
 import { canWrite } from "../domain/permissions/can-write.js";
@@ -999,8 +1000,68 @@ router.get(
     // Get stream
     const streamResult = await getStream({ db }, req.podName, streamId);
 
+    // Special handling for recursive queries - they can work even if exact stream doesn't exist
+    const recursive = req.query.recursive === "true";
+
     if (!streamResult.success || !streamResult.data) {
-      // Provide more informative error message
+      // If this is a recursive query and we're not looking for a specific record,
+      // we can still search for nested streams
+      if (recursive && !name && !indexQuery) {
+        // Try to find nested streams even if the exact stream doesn't exist
+        const config = getConfig();
+        const maxLimit = config.rateLimits.maxRecordLimit;
+
+        let limit = parseInt(req.query.limit as string) || 100;
+        if (limit > maxLimit) {
+          limit = maxLimit;
+        }
+
+        const after = req.query.after
+          ? parseInt(req.query.after as string)
+          : undefined;
+        const unique = req.query.unique === "true";
+
+        if (unique) {
+          res.status(400).json({
+            error: {
+              code: "INVALID_PARAMETERS",
+              message:
+                "Cannot use 'unique' and 'recursive' parameters together",
+            },
+          });
+          return;
+        }
+
+        const result = await listRecordsRecursive(
+          { db },
+          req.podName,
+          streamId,
+          req.auth?.user_id || null,
+          limit,
+          after,
+        );
+
+        if (!result.success) {
+          res.status(500).json({
+            error: result.error,
+          });
+          return;
+        }
+
+        const data = result.data;
+        res.json({
+          records: data.records.map(recordToResponse),
+          total: data.total,
+          hasMore: data.hasMore,
+          nextIndex:
+            data.hasMore && data.records.length > 0
+              ? data.records[data.records.length - 1]?.index
+              : null,
+        });
+        return;
+      }
+
+      // Regular non-recursive case - stream not found
       const fullPath = req.path.substring(1);
       if (name) {
         // We were looking for a record in a stream that doesn't exist
@@ -1268,23 +1329,47 @@ router.get(
         ? parseInt(req.query.after as string)
         : undefined;
       const unique = req.query.unique === "true";
+      // recursive was already defined earlier
 
-      // Use appropriate listing function based on unique parameter
-      const result = unique
-        ? await listUniqueRecords(
-            { db },
-            req.podName,
-            streamResult.data.name,
-            limit,
-            after,
-          )
-        : await listRecords(
-            { db },
-            req.podName,
-            streamResult.data.name,
-            limit,
-            after,
-          );
+      // Use appropriate listing function based on parameters
+      let result;
+      if (recursive) {
+        // Recursive listing doesn't support unique mode yet
+        if (unique) {
+          res.status(400).json({
+            error: {
+              code: "INVALID_PARAMETERS",
+              message:
+                "Cannot use 'unique' and 'recursive' parameters together",
+            },
+          });
+          return;
+        }
+        result = await listRecordsRecursive(
+          { db },
+          req.podName,
+          streamResult.data.name,
+          req.auth?.user_id || null,
+          limit,
+          after,
+        );
+      } else if (unique) {
+        result = await listUniqueRecords(
+          { db },
+          req.podName,
+          streamResult.data.name,
+          limit,
+          after,
+        );
+      } else {
+        result = await listRecords(
+          { db },
+          req.podName,
+          streamResult.data.name,
+          limit,
+          after,
+        );
+      }
 
       if (!result.success) {
         res.status(500).json({
@@ -1293,7 +1378,7 @@ router.get(
         return;
       }
 
-      // Both listRecords and listUniqueRecords now return the same format
+      // All listing functions now return the same format
       const data = result.data as {
         records: StreamRecord[];
         total: number;


### PR DESCRIPTION
Implemented recursive stream queries to fetch records from a stream and all its nested sub-streams. The feature uses a prefix pattern to match streams, supporting hierarchical data organization.

- Added `?recursive=true` query parameter to fetch records from nested streams
- Pattern matches exact stream name plus all streams starting with `{name}/`
- Added CLI support with `--recursive` flag for record list command
- Prevents combining recursive with unique parameter (incompatible operations)
- Fixed CLI JSON output bug when no records are found
- Added comprehensive integration and CLI tests

Example: `/api?recursive=true` returns records from:
- Exact match: `api`
- Nested streams: `api/v1`, `api/v1/users`, `api/v2`, etc.

🤖 Generated with [Claude Code](https://claude.ai/code)