### PR TITLE
fix: Clarify API endpoint notation in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,19 +1339,19 @@ docker-compose -f docker-compose.test.yml up
 
 - `POST /api/pods` - Create pod
 - `GET /api/pods` - List user's pods
-- `DELETE /{pod}.webpods.org/` - Delete pod
+- `DELETE https://{pod}.webpods.org/` - Delete pod
 
 ### Streams
 
-- `POST /{pod}.webpods.org/{stream}?access={mode}` - Create a stream explicitly (or auto-create on first write)
-- `DELETE /{pod}.webpods.org/{stream}` - Delete stream
-- `GET /{pod}.webpods.org/.config/api/streams` - List all streams
+- `POST https://{pod}.webpods.org/{stream}?access={mode}` - Create a stream explicitly (or auto-create on first write)
+- `DELETE https://{pod}.webpods.org/{stream}` - Delete stream
+- `GET https://{pod}.webpods.org/.config/api/streams` - List all streams
 
 ### Records
 
-- `POST /{pod}.webpods.org/{stream}/{name}` - Write record
-- `GET /{pod}.webpods.org/{stream}/{name}` - Read record
-- `GET /{pod}.webpods.org/{stream}` - List records
+- `POST https://{pod}.webpods.org/{stream}/{name}` - Write record
+- `GET https://{pod}.webpods.org/{stream}/{name}` - Read record
+- `GET https://{pod}.webpods.org/{stream}` - List records
 
 ### OAuth Client Management
 


### PR DESCRIPTION
Changed confusing notation from `/{pod}.webpods.org/...` to `https://{pod}.webpods.org/...` to make it clear these are subdomain-based endpoints, not paths.

The previous notation with a leading slash made it appear as if {pod}.webpods.org was part of the path, when it's actually the subdomain in the URL.

🤖 Generated with [Claude Code](https://claude.ai/code)