### PR TITLE
feat: Add content_hash field for efficient content comparison

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ When you begin working on this project, you MUST:
 
 Only after reading these documents should you proceed with any implementation or analysis tasks.
 
+**IMPORTANT**: After every conversation compact/summary, you MUST re-read this CLAUDE.md file again as your first action. The conversation context gets compressed and critical project-specific instructions may be lost. Always start by reading CLAUDE.md after a compact.
+
 ## Documentation Principles
 
 **IMPORTANT**: When writing or updating documentation:
@@ -222,20 +224,22 @@ for (const record of records) {
 
 ### Test Output Strategy for Full Test Suites
 
-**IMPORTANT**: When running the full test suite (which takes 3+ minutes), always save output to a file for efficient analysis:
+**IMPORTANT**: When running the full test suite (which takes 3+ minutes), use `tee` to both display output to the user AND save to a file:
 
 ```bash
 # Create .tests directory if it doesn't exist (gitignored)
 mkdir -p .tests
 
-# Run full test suite and save output
-npm test > .tests/run-$(date +%s).txt 2>&1
+# Run full test suite with tee - shows output to user AND saves to file
+npm test | tee .tests/run-$(date +%s).txt
 
-# Then analyze the saved output multiple times without re-running tests:
+# Then you can analyze the saved output multiple times without re-running tests:
 grep "failing" .tests/run-*.txt
 tail -50 .tests/run-*.txt
 grep -A10 "specific test name" .tests/run-*.txt
 ```
+
+**NEVER use plain redirection (`>` or `2>&1`) as it hides output from the user.** Always use `tee` so the user can see test progress in real-time while you also get a saved copy for analysis.
 
 This strategy prevents the need to re-run lengthy test suites when you need different information from the output. The `.tests/` directory is gitignored to keep test outputs from cluttering the repository.
 

--- a/database/webpods/migrations/20250810000000_initial_schema.js
+++ b/database/webpods/migrations/20250810000000_initial_schema.js
@@ -67,7 +67,8 @@ export async function up(knex) {
     table.text('content'); // Can be text or JSON
     table.string('content_type', 100).defaultTo('text/plain');
     table.string('name', 256).notNullable(); // Required name (like a filename)
-    table.string('hash', 100).notNullable(); // SHA-256 hash with prefix
+    table.string('content_hash', 100).notNullable(); // SHA-256 hash of content only
+    table.string('hash', 100).notNullable(); // SHA-256 hash of (previous_hash + content_hash)
     table.string('previous_hash', 100); // NULL for first record
     table.uuid('user_id').references('id').inTable('user').onDelete('RESTRICT'); // User who created the record
     table.timestamp('created_at').defaultTo(knex.fn.now());

--- a/node/packages/webpods-cli-tests/package-lock.json
+++ b/node/packages/webpods-cli-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods-cli-tests",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods-cli-tests",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@types/chai": "^5.0.1",
         "@types/mocha": "^10.0.10",
@@ -23,7 +23,7 @@
       }
     },
     "../webpods-test-utils": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@types/express": "^5.0.3",
         "express": "^5.1.0",

--- a/node/packages/webpods-cli-tests/src/test-setup.ts
+++ b/node/packages/webpods-cli-tests/src/test-setup.ts
@@ -4,6 +4,7 @@
 
 import { TestDatabase, createTestUser } from "webpods-test-utils";
 import { sign } from "jsonwebtoken";
+import { createHash } from "crypto";
 import { CliTestServer } from "./cli-test-server.js";
 
 // Global test context
@@ -99,4 +100,30 @@ export async function resetCliTestDb(): Promise<void> {
   });
 
   testToken = createTestJWT(testUser.userId, testUser.email);
+}
+
+/**
+ * Calculate content hash for a record
+ */
+export function calculateContentHash(content: unknown): string {
+  const data = typeof content === "string" ? content : JSON.stringify(content);
+  return "sha256:" + createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Calculate record hash
+ */
+export function calculateRecordHash(
+  previousHash: string | null,
+  contentHash: string,
+  userId: string,
+  timestamp: string,
+): string {
+  const data = JSON.stringify({
+    previous_hash: previousHash,
+    content_hash: contentHash,
+    user_id: userId,
+    timestamp: timestamp,
+  });
+  return "sha256:" + createHash("sha256").update(data).digest("hex");
 }

--- a/node/packages/webpods-cli-tests/src/tests/domains.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/domains.test.ts
@@ -11,6 +11,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Domain Commands", function () {
@@ -54,17 +56,29 @@ describe("CLI Domain Commands", function () {
       );
 
     // Add owner record
+    const ownerContent = JSON.stringify({ owner: testUser.userId });
+    const contentHash = calculateContentHash(ownerContent);
+    const timestamp = new Date().toISOString();
+    const hash = calculateRecordHash(
+      null,
+      contentHash,
+      testUser.userId,
+      timestamp,
+    );
+
     await testDb.getDb().none(
-      `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-       VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+      `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+       VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
       {
         podName: testPodName,
         streamName: "/.config/owner",
         name: "owner",
-        content: JSON.stringify({ owner: testUser.userId }),
+        content: ownerContent,
         contentType: "application/json",
-        hash: "hash-owner",
+        contentHash,
+        hash,
         userId: testUser.userId,
+        timestamp,
       },
     );
   });

--- a/node/packages/webpods-cli-tests/src/tests/export.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/export.test.ts
@@ -12,6 +12,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Export Command", function () {
@@ -66,25 +68,39 @@ describe("CLI Export Command", function () {
         );
 
       // Add some records to each stream
+      let previousHash: string | null = null;
       for (let i = 0; i < 3; i++) {
+        const content = JSON.stringify({
+          stream: stream.name,
+          index: i,
+          data: `Content for ${stream.name} record ${i}`,
+        });
+        const contentHash = calculateContentHash(content);
+        const timestamp = new Date().toISOString();
+        const hash = calculateRecordHash(
+          previousHash,
+          contentHash,
+          testUser.userId,
+          timestamp,
+        );
+
         await testDb.getDb().none(
-          `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-           VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), $(index))`,
+          `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+           VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), $(index), $(timestamp))`,
           {
             podName: testPodName,
             streamName: stream.name,
             name: `record-${i}`,
-            content: JSON.stringify({
-              stream: stream.name,
-              index: i,
-              data: `Content for ${stream.name} record ${i}`,
-            }),
+            content,
             contentType: "application/json",
-            hash: `sha256:hash-${stream.name}-${i}`,
+            contentHash,
+            hash,
             userId: testUser.userId,
             index: i,
+            timestamp,
           },
         );
+        previousHash = hash;
       }
     }
   });

--- a/node/packages/webpods-cli-tests/src/tests/links.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/links.test.ts
@@ -11,6 +11,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Links Commands", function () {
@@ -54,17 +56,29 @@ describe("CLI Links Commands", function () {
       );
 
     // Add owner record
+    const content = JSON.stringify({ owner: testUser.userId });
+    const contentHash = calculateContentHash(content);
+    const timestamp = new Date().toISOString();
+    const hash = calculateRecordHash(
+      null,
+      contentHash,
+      testUser.userId,
+      timestamp,
+    );
+
     await testDb.getDb().none(
-      `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-       VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+      `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+       VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
       {
         podName: testPodName,
         streamName: "/.config/owner",
         name: "owner",
-        content: JSON.stringify({ owner: testUser.userId }),
+        content,
         contentType: "application/json",
-        hash: "hash-owner",
+        contentHash,
+        hash,
         userId: testUser.userId,
+        timestamp,
       },
     );
   });

--- a/node/packages/webpods-cli-tests/src/tests/pods.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/pods.test.ts
@@ -12,6 +12,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Pod Commands", function () {
@@ -126,17 +128,29 @@ describe("CLI Pod Commands", function () {
           );
 
         // Add owner record
+        const ownerContent = JSON.stringify({ owner: testUser.userId });
+        const contentHash = calculateContentHash(ownerContent);
+        const timestamp = new Date().toISOString();
+        const hash = calculateRecordHash(
+          null,
+          contentHash,
+          testUser.userId,
+          timestamp,
+        );
+
         await testDb.getDb().none(
-          `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-           VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+          `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+           VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
           {
             podName,
             streamName: "/.config/owner",
             name: "owner",
-            content: JSON.stringify({ owner: testUser.userId }),
+            content: ownerContent,
             contentType: "application/json",
-            hash: "hash-" + podName,
+            contentHash,
+            hash,
             userId: testUser.userId,
+            timestamp,
           },
         );
       }
@@ -205,17 +219,29 @@ describe("CLI Pod Commands", function () {
         );
 
       // Add owner record
+      const ownerContent = JSON.stringify({ owner: testUser.userId });
+      const contentHash = calculateContentHash(ownerContent);
+      const timestamp = new Date().toISOString();
+      const hash = calculateRecordHash(
+        null,
+        contentHash,
+        testUser.userId,
+        timestamp,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
         {
           podName: "test-pod",
           streamName: "/.config/owner",
           name: "owner",
-          content: JSON.stringify({ owner: testUser.userId }),
+          content: ownerContent,
           contentType: "application/json",
-          hash: "hash-test-pod",
+          contentHash,
+          hash,
           userId: testUser.userId,
+          timestamp,
         },
       );
     });
@@ -277,17 +303,29 @@ describe("CLI Pod Commands", function () {
         );
 
       // Add owner record
+      const ownerContent = JSON.stringify({ owner: testUser.userId });
+      const contentHash = calculateContentHash(ownerContent);
+      const timestamp = new Date().toISOString();
+      const hash = calculateRecordHash(
+        null,
+        contentHash,
+        testUser.userId,
+        timestamp,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
         {
           podName: "test-pod",
           streamName: "/.config/owner",
           name: "owner",
-          content: JSON.stringify({ owner: testUser.userId }),
+          content: ownerContent,
           contentType: "application/json",
-          hash: "hash-test-pod",
+          contentHash,
+          hash,
           userId: testUser.userId,
+          timestamp,
         },
       );
     });

--- a/node/packages/webpods-cli-tests/src/tests/records.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/records.test.ts
@@ -12,6 +12,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Record Commands", function () {
@@ -189,34 +191,58 @@ describe("CLI Record Commands", function () {
           },
         );
 
+      const content1 = '{"value": 1}';
+      const contentHash1 = calculateContentHash(content1);
+      const timestamp1 = new Date().toISOString();
+      const hash1 = calculateRecordHash(
+        null,
+        contentHash1,
+        testUser.userId,
+        timestamp1,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(hash), $(userId), $(index))`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(contentHash), $(hash), $(userId), $(index), $(timestamp))`,
         {
           podName: testPodName,
           streamName: "/test-stream",
           recordName: "record1",
-          content: '{"value": 1}',
+          content: content1,
           contentType: "application/json",
-          hash: "hash1",
+          contentHash: contentHash1,
+          hash: hash1,
           userId: testUser.userId,
           index: 0,
+          timestamp: timestamp1,
         },
       );
 
+      const content2 = '{"value": 2}';
+      const contentHash2 = calculateContentHash(content2);
+      const timestamp2 = new Date().toISOString();
+      const hash2 = calculateRecordHash(
+        hash1,
+        contentHash2,
+        testUser.userId,
+        timestamp2,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, previous_hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(hash), $(previous), $(userId), $(index))`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, previous_hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(contentHash), $(hash), $(previous), $(userId), $(index), $(timestamp))`,
         {
           podName: testPodName,
           streamName: "/test-stream",
           recordName: "record2",
-          content: '{"value": 2}',
+          content: content2,
           contentType: "application/json",
-          hash: "hash2",
-          previous: "hash1",
+          contentHash: contentHash2,
+          hash: hash2,
+          previous: hash1,
           userId: testUser.userId,
           index: 1,
+          timestamp: timestamp2,
         },
       );
     });
@@ -327,21 +353,35 @@ describe("CLI Record Commands", function () {
           },
         );
 
+      let previousHash: string | null = null;
       for (let i = 0; i < 10; i++) {
+        const content = `{"index": ${i}}`;
+        const contentHash = calculateContentHash(content);
+        const timestamp = new Date().toISOString();
+        const hash = calculateRecordHash(
+          previousHash,
+          contentHash,
+          testUser.userId,
+          timestamp,
+        );
+
         await testDb.getDb().none(
-          `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-           VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), $(index))`,
+          `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+           VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), $(index), $(timestamp))`,
           {
             podName: testPodName,
             streamName: "/test-stream",
             name: `record${i}`,
-            content: `{"index": ${i}}`,
+            content,
             contentType: "application/json",
-            hash: `hash${i}`,
+            contentHash,
+            hash,
             userId: testUser.userId,
             index: i,
+            timestamp,
           },
         );
+        previousHash = hash;
       }
     });
 
@@ -405,19 +445,39 @@ describe("CLI Record Commands", function () {
     });
 
     it("should list only unique records when flag is set", async () => {
+      // Get the last record's hash to continue the chain
+      const lastRecord = await testDb.getDb().one(
+        `SELECT hash FROM record 
+         WHERE pod_name = $(podName) AND stream_name = $(streamName)
+         ORDER BY index DESC LIMIT 1`,
+        { podName: testPodName, streamName: "/test-stream" },
+      );
+
       // Add duplicate named records
+      const duplicateContent = '{"updated": true}';
+      const duplicateContentHash = calculateContentHash(duplicateContent);
+      const duplicateTimestamp = new Date().toISOString();
+      const duplicateHash = calculateRecordHash(
+        lastRecord.hash,
+        duplicateContentHash,
+        testUser.userId,
+        duplicateTimestamp,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(hash), $(userId), $(index))`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(contentHash), $(hash), $(userId), $(index), $(timestamp))`,
         {
           podName: testPodName,
           streamName: "/test-stream",
           recordName: "record1",
-          content: '{"updated": true}',
+          content: duplicateContent,
           contentType: "application/json",
-          hash: "hash-new",
+          contentHash: duplicateContentHash,
+          hash: duplicateHash,
           userId: testUser.userId,
           index: 10,
+          timestamp: duplicateTimestamp,
         },
       );
 
@@ -599,17 +659,29 @@ describe("CLI Record Commands", function () {
         );
 
       // Add owner record
+      const ownerContent = JSON.stringify({ owner: testUser.userId });
+      const ownerContentHash = calculateContentHash(ownerContent);
+      const ownerTimestamp = new Date().toISOString();
+      const ownerHash = calculateRecordHash(
+        null,
+        ownerContentHash,
+        testUser.userId,
+        ownerTimestamp,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
         {
           podName: testPodName,
           streamName: "/.config/owner",
           name: "owner",
-          content: JSON.stringify({ owner: testUser.userId }),
+          content: ownerContent,
           contentType: "application/json",
-          hash: "hash-owner",
+          contentHash: ownerContentHash,
+          hash: ownerHash,
           userId: testUser.userId,
+          timestamp: ownerTimestamp,
         },
       );
 
@@ -625,18 +697,30 @@ describe("CLI Record Commands", function () {
           },
         );
 
+      const testContent = '{"test": true}';
+      const testContentHash = calculateContentHash(testContent);
+      const testTimestamp = new Date().toISOString();
+      const testHash = calculateRecordHash(
+        ownerHash,
+        testContentHash,
+        testUser.userId,
+        testTimestamp,
+      );
+
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(hash), $(userId), $(index))`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(recordName), $(content), $(contentType), $(contentHash), $(hash), $(userId), $(index), $(timestamp))`,
         {
           podName: testPodName,
           streamName: "/test-stream",
           recordName: "record1",
-          content: '{"test": true}',
+          content: testContent,
           contentType: "application/json",
-          hash: "hash1",
+          contentHash: testContentHash,
+          hash: testHash,
           userId: testUser.userId,
           index: 0,
+          timestamp: testTimestamp,
         },
       );
     });

--- a/node/packages/webpods-cli-tests/src/tests/recursive-records.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/recursive-records.test.ts
@@ -11,6 +11,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Recursive Records", function () {
@@ -76,16 +78,27 @@ describe("CLI Recursive Records", function () {
       ];
 
       for (const record of records) {
+        const contentHash = calculateContentHash(record.content);
+        const timestamp = new Date().toISOString();
+        const hash = calculateRecordHash(
+          null,
+          contentHash,
+          testUser.userId,
+          timestamp,
+        );
+
         await db.none(
-          `INSERT INTO record (pod_name, stream_name, index, name, content, content_type, hash, user_id, created_at)
-           VALUES ($(podName), $(streamName), 0, $(name), $(content), 'application/json', 
-                   'sha256:' || encode(sha256($(content)::bytea), 'hex'), $(userId), NOW())`,
+          `INSERT INTO record (pod_name, stream_name, index, name, content, content_type, content_hash, hash, user_id, created_at)
+           VALUES ($(podName), $(streamName), 0, $(name), $(content), 'application/json', $(contentHash), $(hash), $(userId), $(timestamp))`,
           {
             podName: testPodName,
             streamName: record.stream,
             name: record.name,
             content: record.content,
+            contentHash,
+            hash,
             userId: testUser.userId,
+            timestamp,
           },
         );
       }
@@ -166,20 +179,34 @@ describe("CLI Recursive Records", function () {
     it("should work with pagination parameters", async () => {
       // Add more records to test pagination
       const db = testDb.getDb();
+      let previousHash: string | null = null;
       for (let i = 2; i <= 5; i++) {
+        const content = JSON.stringify({ data: `api root ${i}` });
+        const contentHash = calculateContentHash(content);
+        const timestamp = new Date().toISOString();
+        const hash = calculateRecordHash(
+          previousHash,
+          contentHash,
+          testUser.userId,
+          timestamp,
+        );
+
         await db.none(
-          `INSERT INTO record (pod_name, stream_name, index, name, content, content_type, hash, user_id, created_at)
-           VALUES ($(podName), $(streamName), $(index), $(name), $(content), 'application/json', 
-                   'sha256:' || encode(sha256($(content)::bytea), 'hex'), $(userId), NOW())`,
+          `INSERT INTO record (pod_name, stream_name, index, name, content, content_type, content_hash, hash, user_id, created_at)
+           VALUES ($(podName), $(streamName), $(index), $(name), $(content), 'application/json', $(contentHash), $(hash), $(userId), $(timestamp))`,
           {
             podName: testPodName,
             streamName: "/api",
             index: i - 1,
             name: `record${i}`,
-            content: JSON.stringify({ data: `api root ${i}` }),
+            content,
+            contentHash,
+            hash,
             userId: testUser.userId,
+            timestamp,
           },
         );
+        previousHash = hash;
       }
 
       const result = await cli.exec(

--- a/node/packages/webpods-cli-tests/src/tests/transfer.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/transfer.test.ts
@@ -13,6 +13,8 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
 
 describe("CLI Transfer Command", function () {
@@ -58,17 +60,29 @@ describe("CLI Transfer Command", function () {
       );
 
     // Add owner record
+    const ownerContent = JSON.stringify({ owner: testUser.userId });
+    const ownerContentHash = calculateContentHash(ownerContent);
+    const ownerTimestamp = new Date().toISOString();
+    const ownerHash = calculateRecordHash(
+      null,
+      ownerContentHash,
+      testUser.userId,
+      ownerTimestamp,
+    );
+
     await testDb.getDb().none(
-      `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index) 
-       VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0)`,
+      `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+       VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(timestamp))`,
       {
         podName: testPodName,
         streamName: "/.config/owner",
         name: "owner",
-        content: JSON.stringify({ owner: testUser.userId }),
+        content: ownerContent,
         contentType: "application/json",
-        hash: "hash-owner",
+        contentHash: ownerContentHash,
+        hash: ownerHash,
         userId: testUser.userId,
+        timestamp: ownerTimestamp,
       },
     );
 

--- a/node/packages/webpods-cli-tests/src/tests/verify.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/verify.test.ts
@@ -11,8 +11,9 @@ import {
   testToken,
   testUser,
   testDb,
+  calculateContentHash,
+  calculateRecordHash,
 } from "../test-setup.js";
-import crypto from "crypto";
 
 describe("CLI Verify Command", function () {
   this.timeout(30000);
@@ -56,29 +57,29 @@ describe("CLI Verify Command", function () {
       );
 
     // Add records with proper hash chain
-    let previousHash = null;
+    let previousHash: string | null = null;
     for (let i = 0; i < 5; i++) {
       const contentObj = { index: i, data: `Record ${i}` };
       const content = JSON.stringify(contentObj);
+      const contentHash = calculateContentHash(content);
       const timestamp = new Date().toISOString();
-
-      // Calculate hash exactly like the server does
-      const hashData: string = JSON.stringify({
-        previous_hash: previousHash,
-        timestamp: timestamp,
-        content: contentObj, // Use the object, not the string
-      });
-      const hash: string = `sha256:${crypto.createHash("sha256").update(hashData).digest("hex")}`;
+      const hash = calculateRecordHash(
+        previousHash,
+        contentHash,
+        testUser.userId,
+        timestamp,
+      );
 
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, previous_hash, user_id, index, created_at) 
-         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(previousHash), $(userId), $(index), $(createdAt))`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, previous_hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(previousHash), $(userId), $(index), $(createdAt))`,
         {
           podName: testPodName,
           streamName: "/test-stream",
           name: `record-${i}`,
           content,
           contentType: "application/json",
+          contentHash,
           hash,
           previousHash,
           userId: testUser.userId,
@@ -256,25 +257,25 @@ describe("CLI Verify Command", function () {
       // Add a record with proper hash
       const contentObj = { public: true };
       const content = JSON.stringify(contentObj);
+      const contentHash = calculateContentHash(content);
       const timestamp = new Date().toISOString();
-
-      // Calculate hash exactly like the server does
-      const hashData: string = JSON.stringify({
-        previous_hash: null,
-        timestamp: timestamp,
-        content: contentObj, // Use the object, not the string
-      });
-      const hash: string = `sha256:${crypto.createHash("sha256").update(hashData).digest("hex")}`;
+      const hash = calculateRecordHash(
+        null,
+        contentHash,
+        testUser.userId,
+        timestamp,
+      );
 
       await testDb.getDb().none(
-        `INSERT INTO record (pod_name, stream_name, name, content, content_type, hash, user_id, index, created_at) 
-         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(hash), $(userId), 0, $(createdAt))`,
+        `INSERT INTO record (pod_name, stream_name, name, content, content_type, content_hash, hash, user_id, index, created_at) 
+         VALUES ($(podName), $(streamName), $(name), $(content), $(contentType), $(contentHash), $(hash), $(userId), 0, $(createdAt))`,
         {
           podName: testPodName,
           streamName: "/public-stream",
           name: "record-0",
           content,
           contentType: "application/json",
+          contentHash,
           hash,
           userId: testUser.userId,
           createdAt: timestamp,

--- a/node/packages/webpods-cli/package-lock.json
+++ b/node/packages/webpods-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods-cli",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.10.10",

--- a/node/packages/webpods-cli/src/commands/records/records.ts
+++ b/node/packages/webpods-cli/src/commands/records/records.ts
@@ -402,14 +402,14 @@ export async function list(options: {
           output.print(`content_type: ${record.content_type}`);
           output.print(`hash: ${record.hash}`);
           output.print(`timestamp: ${record.timestamp}`);
-          output.print(`author: ${record.author}`);
+          output.print(`userId: ${record.userId}`);
         });
         break;
       case "csv":
-        output.print("index,name,content_type,hash,timestamp,author");
+        output.print("index,name,content_type,hash,timestamp,userId");
         response.records.forEach((record) => {
           output.print(
-            `${record.index},"${record.name}","${record.content_type}","${record.hash}","${record.timestamp}","${record.author}"`,
+            `${record.index},"${record.name}","${record.content_type}","${record.hash}","${record.timestamp}","${record.userId}"`,
           );
         });
         break;

--- a/node/packages/webpods-cli/src/commands/verify/verify.ts
+++ b/node/packages/webpods-cli/src/commands/verify/verify.ts
@@ -77,11 +77,12 @@ export async function verify(argv: Arguments) {
         }
 
         // Verify the hash itself
-        // Server uses: previous_hash, timestamp, content (the original object, not stringified)
+        // Server uses: hash(previous_hash + content_hash + user_id + timestamp)
         const hashData = JSON.stringify({
           previous_hash: record.previousHash || null,
+          content_hash: record.contentHash,
+          user_id: record.userId,
           timestamp: record.timestamp,
-          content: record.content,
         });
 
         const computedHash = crypto

--- a/node/packages/webpods-cli/src/types.ts
+++ b/node/packages/webpods-cli/src/types.ts
@@ -74,10 +74,13 @@ export interface StreamRecord {
   index: number;
   content: unknown;
   content_type: string;
+  contentType?: string; // API returns camelCase
   name: string;
+  contentHash: string;
   hash: string;
   previous_hash: string | null;
-  author: string;
+  previousHash?: string | null; // API returns camelCase
+  userId: string;
   timestamp: string;
 }
 

--- a/node/packages/webpods-integration-tests/package-lock.json
+++ b/node/packages/webpods-integration-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods-integration-tests",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods-integration-tests",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "@types/chai": "^5.2.2",
         "@types/jsonwebtoken": "^9.0.10",
@@ -21,7 +21,7 @@
       }
     },
     "../webpods-test-utils": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dev": true,
       "dependencies": {
         "@types/express": "^5.0.3",

--- a/node/packages/webpods-integration-tests/src/tests/auth.test.ts
+++ b/node/packages/webpods-integration-tests/src/tests/auth.test.ts
@@ -119,7 +119,7 @@ describe("WebPods Authentication", () => {
 
       expect(response.status).to.equal(201);
       expect(response.data).to.have.property("index", 0);
-      expect(response.data).to.have.property("author", userId);
+      expect(response.data).to.have.property("userId", userId);
     });
 
     it("should reject invalid OAuth token", async () => {
@@ -226,7 +226,7 @@ describe("WebPods Authentication", () => {
       });
 
       expect(response.status).to.equal(201);
-      expect(response.data.author).to.equal(userId);
+      expect(response.data.userId).to.equal(userId);
 
       // Verify in database
       const db = testDb.getDb();

--- a/node/packages/webpods-integration-tests/src/tests/images.test.ts
+++ b/node/packages/webpods-integration-tests/src/tests/images.test.ts
@@ -66,6 +66,7 @@ describe("WebPods Image Support", () => {
       expect(response.data).to.have.property("contentType", "image/png");
       expect(response.data).to.have.property("name", "main-logo");
       expect(response.data).to.have.property("hash");
+      expect(response.data).to.have.property("contentHash");
     });
 
     it("should upload image using data URL", async () => {
@@ -196,6 +197,7 @@ describe("WebPods Image Support", () => {
       const response = await client.get("/gallery/photo1/first");
 
       expect(response.status).to.equal(200);
+      expect(response.headers).to.have.property("x-content-hash");
       expect(response.headers).to.have.property("x-hash");
       expect(response.headers).to.have.property("x-author", userId);
       expect(response.headers).to.have.property("x-timestamp");

--- a/node/packages/webpods-integration-tests/src/tests/streams.test.ts
+++ b/node/packages/webpods-integration-tests/src/tests/streams.test.ts
@@ -179,6 +179,17 @@ describe("WebPods Stream Operations", () => {
 
       // Verify hash format
       expect(response1.data.hash).to.match(/^sha256:[a-f0-9]{64}$/);
+
+      // Verify contentHash exists and is different from record hash
+      expect(response1.data.contentHash).to.exist;
+      expect(response1.data.contentHash).to.match(/^sha256:[a-f0-9]{64}$/);
+      expect(response1.data.contentHash).to.not.equal(response1.data.hash);
+
+      // Content hash should be the same for identical content
+      const duplicate = await client.post("/hash-test/duplicate", "First");
+      expect(duplicate.data.contentHash).to.equal(response1.data.contentHash);
+      // But record hash should be different (different position in chain)
+      expect(duplicate.data.hash).to.not.equal(response1.data.hash);
     });
 
     it("should support names (including numeric)", async () => {
@@ -290,6 +301,7 @@ describe("WebPods Stream Operations", () => {
       const response = await client.get("/read-test?i=0");
       // Express adds charset, so check if content-type starts with expected value
       expect(response.headers["content-type"]).to.include("text/plain");
+      expect(response.headers["x-content-hash"]).to.exist;
       expect(response.headers["x-hash"]).to.exist;
       expect(response.headers["x-author"]).to.equal(userId);
       expect(response.headers["x-timestamp"]).to.exist;

--- a/node/packages/webpods-test-utils/package-lock.json
+++ b/node/packages/webpods-test-utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods-test-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods-test-utils",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@types/express": "^5.0.3",
         "express": "^5.1.0",

--- a/node/packages/webpods-test-utils/src/utils/test-helpers.ts
+++ b/node/packages/webpods-test-utils/src/utils/test-helpers.ts
@@ -84,13 +84,26 @@ export async function createTestPod(
   );
 
   // Add ownership record
-  const content = JSON.stringify({ owner: ownerId });
-  const hash = crypto.createHash("sha256").update(content).digest("hex");
+  const ownerObj = { owner: ownerId };
+  const content = JSON.stringify(ownerObj);
+  const contentHash =
+    "sha256:" + crypto.createHash("sha256").update(content).digest("hex");
+  const timestamp = new Date().toISOString();
+
+  // Calculate record hash (previousHash + contentHash + userId + timestamp)
+  const hashData = JSON.stringify({
+    previous_hash: null,
+    content_hash: contentHash,
+    user_id: ownerId,
+    timestamp: timestamp,
+  });
+  const hash =
+    "sha256:" + crypto.createHash("sha256").update(hashData).digest("hex");
 
   await db.none(
-    `INSERT INTO record (pod_name, stream_name, index, content, content_type, name, hash, previous_hash, user_id, created_at)
-     VALUES ($(podName), '/.config/owner', 0, $(content), 'application/json', 'owner', $(hash), NULL, $(ownerId), NOW())`,
-    { podName, content, hash, ownerId },
+    `INSERT INTO record (pod_name, stream_name, index, content, content_type, name, content_hash, hash, previous_hash, user_id, created_at)
+     VALUES ($(podName), '/.config/owner', 0, $(content), 'application/json', 'owner', $(contentHash), $(hash), NULL, $(ownerId), $(timestamp))`,
+    { podName, content, contentHash, hash, ownerId, timestamp },
   );
 }
 

--- a/node/packages/webpods/package-lock.json
+++ b/node/packages/webpods/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "license": "MIT",
       "dependencies": {
         "@ory/hydra-client": "^2.4.0-alpha.1",

--- a/node/packages/webpods/src/db-types.ts
+++ b/node/packages/webpods/src/db-types.ts
@@ -50,7 +50,8 @@ export type RecordDbRow = {
   index: number;
   content: string;
   content_type: string;
-  hash: string;
+  content_hash: string; // SHA-256 hash of content only
+  hash: string; // SHA-256 hash of (previous_hash + content_hash)
   previous_hash?: string | null;
   user_id: string; // References user.id
   name?: string | null;

--- a/node/packages/webpods/src/domain/pods/create-pod.ts
+++ b/node/packages/webpods/src/domain/pods/create-pod.ts
@@ -7,7 +7,11 @@ import { Result, success, failure } from "../../utils/result.js";
 import { createError } from "../../utils/errors.js";
 import { PodDbRow, StreamDbRow } from "../../db-types.js";
 import { Pod } from "../../types.js";
-import { isValidPodName, calculateRecordHash } from "../../utils.js";
+import {
+  isValidPodName,
+  calculateContentHash,
+  calculateRecordHash,
+} from "../../utils.js";
 import { createLogger } from "../../logger.js";
 import { sql } from "../../db/index.js";
 
@@ -81,7 +85,8 @@ export async function createPod(
       // Write initial owner record with snake_case parameters
       const ownerContent = { owner: userId };
       const timestamp = new Date().toISOString();
-      const hash = calculateRecordHash(null, timestamp, ownerContent);
+      const contentHash = calculateContentHash(ownerContent);
+      const hash = calculateRecordHash(null, contentHash, userId, timestamp);
 
       const recordParams = {
         pod_name: pod.name,
@@ -90,6 +95,7 @@ export async function createPod(
         content: JSON.stringify(ownerContent),
         content_type: "application/json",
         name: "owner",
+        content_hash: contentHash,
         hash: hash,
         previous_hash: null,
         user_id: userId,

--- a/node/packages/webpods/src/domain/pods/transfer-pod-ownership.ts
+++ b/node/packages/webpods/src/domain/pods/transfer-pod-ownership.ts
@@ -6,7 +6,7 @@ import { DataContext } from "../data-context.js";
 import { Result, success, failure } from "../../utils/result.js";
 import { createError } from "../../utils/errors.js";
 import { StreamDbRow, RecordDbRow } from "../../db-types.js";
-import { calculateRecordHash } from "../../utils.js";
+import { calculateContentHash, calculateRecordHash } from "../../utils.js";
 import { createLogger } from "../../logger.js";
 import { sql } from "../../db/index.js";
 
@@ -87,10 +87,12 @@ export async function transferPodOwnership(
 
       // Create new owner record
       const newOwnerContent = { owner: toUserId };
+      const contentHash = calculateContentHash(newOwnerContent);
       const hash = calculateRecordHash(
         previousHash,
+        contentHash,
+        fromUserId,
         timestamp,
-        newOwnerContent,
       );
 
       // Insert new owner record with snake_case parameters
@@ -101,6 +103,7 @@ export async function transferPodOwnership(
         content: JSON.stringify(newOwnerContent),
         content_type: "application/json",
         name: "owner",
+        content_hash: contentHash,
         hash: hash,
         previous_hash: previousHash,
         user_id: fromUserId,

--- a/node/packages/webpods/src/domain/records/get-record-range.ts
+++ b/node/packages/webpods/src/domain/records/get-record-range.ts
@@ -23,6 +23,7 @@ function mapRecordFromDb(row: RecordDbRow): StreamRecord {
     content: row.content,
     contentType: row.content_type,
     name: row.name || "",
+    contentHash: row.content_hash,
     hash: row.hash,
     previousHash: row.previous_hash || null,
     userId: row.user_id,

--- a/node/packages/webpods/src/domain/records/get-record.ts
+++ b/node/packages/webpods/src/domain/records/get-record.ts
@@ -24,6 +24,7 @@ function mapRecordFromDb(row: RecordDbRow): StreamRecord {
     content: row.content,
     contentType: row.content_type,
     name: row.name || "",
+    contentHash: row.content_hash,
     hash: row.hash,
     previousHash: row.previous_hash || null,
     userId: row.user_id,

--- a/node/packages/webpods/src/domain/records/list-records-recursive.ts
+++ b/node/packages/webpods/src/domain/records/list-records-recursive.ts
@@ -25,6 +25,7 @@ function mapRecordFromDb(row: RecordDbRow): StreamRecord {
     content: row.content,
     contentType: row.content_type,
     name: row.name || "",
+    contentHash: row.content_hash,
     hash: row.hash,
     previousHash: row.previous_hash || null,
     userId: row.user_id,

--- a/node/packages/webpods/src/domain/records/list-records.ts
+++ b/node/packages/webpods/src/domain/records/list-records.ts
@@ -23,6 +23,7 @@ function mapRecordFromDb(row: RecordDbRow): StreamRecord {
     content: row.content,
     contentType: row.content_type,
     name: row.name || "",
+    contentHash: row.content_hash,
     hash: row.hash,
     previousHash: row.previous_hash || null,
     userId: row.user_id,

--- a/node/packages/webpods/src/domain/records/list-unique-records.ts
+++ b/node/packages/webpods/src/domain/records/list-unique-records.ts
@@ -23,6 +23,7 @@ function mapRecordFromDb(row: RecordDbRow): StreamRecord {
     content: row.content,
     contentType: row.content_type,
     name: row.name || "",
+    contentHash: row.content_hash,
     hash: row.hash,
     previousHash: row.previous_hash || null,
     userId: row.user_id,

--- a/node/packages/webpods/src/domain/records/record-to-response.ts
+++ b/node/packages/webpods/src/domain/records/record-to-response.ts
@@ -24,9 +24,10 @@ export function recordToResponse(record: StreamRecord): StreamRecordResponse {
     content: content,
     contentType: record.contentType,
     name: record.name,
+    contentHash: record.contentHash,
     hash: record.hash,
     previousHash: record.previousHash,
-    author: record.userId,
+    userId: record.userId,
     timestamp: record.createdAt.toISOString(),
   };
 }

--- a/node/packages/webpods/src/domain/records/write-record.ts
+++ b/node/packages/webpods/src/domain/records/write-record.ts
@@ -7,7 +7,11 @@ import { Result, success, failure } from "../../utils/result.js";
 import { createError } from "../../utils/errors.js";
 import { RecordDbRow } from "../../db-types.js";
 import { StreamRecord } from "../../types.js";
-import { calculateRecordHash, isValidName } from "../../utils.js";
+import {
+  calculateContentHash,
+  calculateRecordHash,
+  isValidName,
+} from "../../utils.js";
 import { createLogger } from "../../logger.js";
 import { sql } from "../../db/index.js";
 import { normalizeStreamName } from "../../utils/stream-utils.js";
@@ -26,6 +30,7 @@ function mapRecordFromDb(row: RecordDbRow): StreamRecord {
     content: row.content,
     contentType: row.content_type,
     name: row.name || "",
+    contentHash: row.content_hash,
     hash: row.hash,
     previousHash: row.previous_hash || null,
     userId: row.user_id,
@@ -43,7 +48,7 @@ export async function writeRecord(
   streamId: string,
   content: unknown,
   contentType: string,
-  authorId: string,
+  userId: string,
   name: string,
 ): Promise<Result<StreamRecord>> {
   // Normalize stream name to ensure leading slash
@@ -75,8 +80,16 @@ export async function writeRecord(
       const previousHash = previousRecord?.hash || null;
       const timestamp = new Date().toISOString();
 
-      // Calculate hash
-      const hash = calculateRecordHash(previousHash, timestamp, content);
+      // Calculate content hash first
+      const contentHash = calculateContentHash(content);
+
+      // Calculate record hash with all parameters
+      const hash = calculateRecordHash(
+        previousHash,
+        contentHash,
+        userId,
+        timestamp,
+      );
 
       // Prepare content for storage
       let storedContent = content;
@@ -92,9 +105,10 @@ export async function writeRecord(
         content: storedContent,
         content_type: contentType,
         name: name,
+        content_hash: contentHash,
         hash: hash,
         previous_hash: previousHash,
-        user_id: authorId,
+        user_id: userId,
         created_at: timestamp,
       };
 

--- a/node/packages/webpods/src/domain/routing/update-custom-domains.ts
+++ b/node/packages/webpods/src/domain/routing/update-custom-domains.ts
@@ -5,7 +5,7 @@
 import { DataContext } from "../data-context.js";
 import { Result, success, failure } from "../../utils/result.js";
 import { PodDbRow, StreamDbRow, RecordDbRow } from "../../db-types.js";
-import { calculateRecordHash } from "../../utils.js";
+import { calculateContentHash, calculateRecordHash } from "../../utils.js";
 import { createLogger } from "../../logger.js";
 import { sql } from "../../db/index.js";
 
@@ -95,7 +95,13 @@ export async function updateCustomDomains(
       // Store the complete list of domains in a single record
       const timestamp = new Date().toISOString();
       const content = { domains };
-      const hash = calculateRecordHash(previousHash, timestamp, content);
+      const contentHash = calculateContentHash(content);
+      const hash = calculateRecordHash(
+        previousHash,
+        contentHash,
+        userId,
+        timestamp,
+      );
 
       const params = {
         pod_name: podName,
@@ -104,6 +110,7 @@ export async function updateCustomDomains(
         content: JSON.stringify(content),
         content_type: "application/json",
         name: `domains`,
+        content_hash: contentHash,
         hash: hash,
         previous_hash: previousHash,
         user_id: userId,

--- a/node/packages/webpods/src/domain/routing/update-links.ts
+++ b/node/packages/webpods/src/domain/routing/update-links.ts
@@ -5,7 +5,7 @@
 import { DataContext } from "../data-context.js";
 import { Result, success, failure } from "../../utils/result.js";
 import { PodDbRow, StreamDbRow, RecordDbRow } from "../../db-types.js";
-import { calculateRecordHash } from "../../utils.js";
+import { calculateContentHash, calculateRecordHash } from "../../utils.js";
 import { createLogger } from "../../logger.js";
 import { sql } from "../../db/index.js";
 
@@ -16,7 +16,6 @@ export async function updateLinks(
   podName: string,
   links: Record<string, string>,
   userId: string,
-  authorId: string,
 ): Promise<Result<void>> {
   try {
     return await ctx.db.tx(async (t) => {
@@ -69,7 +68,13 @@ export async function updateLinks(
       const timestamp = new Date().toISOString();
 
       // Calculate hash
-      const hash = calculateRecordHash(previousHash, timestamp, links);
+      const contentHash = calculateContentHash(links);
+      const hash = calculateRecordHash(
+        previousHash,
+        contentHash,
+        userId,
+        timestamp,
+      );
 
       // Write new links record with all links in one record
       const params = {
@@ -79,9 +84,10 @@ export async function updateLinks(
         content: JSON.stringify(links),
         content_type: "application/json",
         name: `links-${index}`,
+        content_hash: contentHash,
         hash: hash,
         previous_hash: previousHash,
-        user_id: authorId,
+        user_id: userId,
         created_at: timestamp,
       };
 

--- a/node/packages/webpods/src/routes/pods.ts
+++ b/node/packages/webpods/src/routes/pods.ts
@@ -319,7 +319,6 @@ router.post(
         req.podName,
         data,
         req.auth.user_id,
-        req.auth.user_id,
       );
 
       if (!result.success) {
@@ -1158,6 +1157,7 @@ router.get(
 
         // Return raw content for single records
         // Set headers
+        res.setHeader("X-Content-Hash", record.contentHash);
         res.setHeader("X-Hash", record.hash);
         res.setHeader("X-Previous-Hash", record.previousHash || "");
         res.setHeader("X-Author", record.userId);
@@ -1285,6 +1285,7 @@ router.get(
 
       // Return raw content for single records
       // Set headers
+      res.setHeader("X-Content-Hash", record.contentHash);
       res.setHeader("X-Hash", record.hash);
       res.setHeader("X-Previous-Hash", record.previousHash || "");
       res.setHeader("X-Author", record.userId);

--- a/node/packages/webpods/src/types.ts
+++ b/node/packages/webpods/src/types.ts
@@ -66,7 +66,8 @@ export interface StreamRecord {
   content: string | unknown; // Can be text or JSON
   contentType: string;
   name: string; // Required name (like a filename)
-  hash: string;
+  contentHash: string; // SHA-256 hash of content only
+  hash: string; // SHA-256 hash of (previous_hash + content_hash)
   previousHash: string | null;
   userId: string; // User ID who created the record
   metadata?: Record<string, unknown>;
@@ -97,9 +98,10 @@ export interface StreamRecordResponse {
   content: unknown;
   contentType: string;
   name: string;
-  hash: string;
+  contentHash: string; // SHA-256 hash of content only
+  hash: string; // SHA-256 hash of (previous_hash + content_hash)
   previousHash: string | null;
-  author: string;
+  userId: string;
   timestamp: string;
 }
 

--- a/node/packages/webpods/src/utils.ts
+++ b/node/packages/webpods/src/utils.ts
@@ -82,17 +82,27 @@ export function parseIndexQuery(
 }
 
 /**
- * Calculate SHA-256 hash for record
+ * Calculate SHA-256 hash for content only
+ */
+export function calculateContentHash(content: unknown): string {
+  const data = typeof content === "string" ? content : JSON.stringify(content);
+  return "sha256:" + createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Calculate SHA-256 hash for record (chain hash)
  */
 export function calculateRecordHash(
   previousHash: string | null,
+  contentHash: string,
+  userId: string,
   timestamp: string,
-  content: unknown,
 ): string {
   const data = JSON.stringify({
     previous_hash: previousHash,
+    content_hash: contentHash,
+    user_id: userId,
     timestamp: timestamp,
-    content: content,
   });
 
   return "sha256:" + createHash("sha256").update(data).digest("hex");


### PR DESCRIPTION
- Added content_hash field to record table schema
- Separated content hash from record hash calculation
- Record hash now includes: previousHash + contentHash + userId + timestamp
- Content hash is SHA-256 of content only (for efficient sync/dedup)
- Updated all record creation code to include content_hash
- Standardized on userId field name (removed author field confusion)
- Fixed all tests to work with new hash calculation
- Updated CLI verify command to use new hash format

This enables efficient content comparison without recalculating the full hash chain, which will be useful for sync features.

🤖 Generated with [Claude Code](https://claude.ai/code)