### PR TITLE
chore: Clean up test output by removing console.log statements

### DIFF
--- a/node/packages/webpods-cli-tests/src/tests/records.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/records.test.ts
@@ -294,9 +294,6 @@ describe("CLI Record Commands", function () {
         },
       );
 
-      console.log("List stdout:", result.stdout);
-      console.log("List stderr:", result.stderr);
-      console.log("List exitCode:", result.exitCode);
       expect(result.exitCode).to.equal(0);
       const lines = result.stdout.trim().split("\n");
       expect(lines).to.have.length.greaterThan(0);
@@ -363,10 +360,6 @@ describe("CLI Record Commands", function () {
       expect(result.exitCode).to.equal(0);
       // Parse JSON output to check unique filter
       const output = JSON.parse(result.stdout);
-      console.log(
-        "Unique records:",
-        output.records.map((r: any) => ({ name: r.name, index: r.index })),
-      );
       // Should only show named records (3 records have names) - empty names are excluded
       expect(output.records).to.have.length(3);
       expect(output.records[0].name).to.equal("record0");
@@ -403,10 +396,6 @@ describe("CLI Record Commands", function () {
       const result = await cli.exec(["streams", testPodName, "--quiet=false"], {
         token: testToken,
       });
-
-      console.log("Streams stdout:", result.stdout);
-      console.log("Streams stderr:", result.stderr);
-      console.log("Streams exitCode:", result.exitCode);
 
       // Check the output exists first
       expect(result.exitCode).to.equal(0);

--- a/node/packages/webpods-cli-tests/src/tests/verify.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/verify.test.ts
@@ -153,9 +153,6 @@ describe("CLI Verify Command", function () {
         },
       );
 
-      console.log("Verify stdout:", result.stdout);
-      console.log("Verify stderr:", result.stderr);
-      console.log("Verify exitCode:", result.exitCode);
       expect(result.exitCode).to.equal(0);
       expect(result.stdout).to.include(
         "Verifying integrity of stream '/test-stream'",

--- a/node/packages/webpods-integration-tests/src/tests/streams-api.test.ts
+++ b/node/packages/webpods-integration-tests/src/tests/streams-api.test.ts
@@ -106,21 +106,6 @@ describe("Streams API", () => {
 
   describe("GET /.config/api/streams", () => {
     it("should list all streams by default", async () => {
-      // First, let's debug what streams actually exist in the database
-      const db = testDb.getDb();
-      const dbStreams = await db.manyOrNone(
-        `SELECT name, parent_id, id FROM stream WHERE pod_name = $(podName) ORDER BY name`,
-        { podName },
-      );
-      console.log(
-        "DB streams:",
-        dbStreams.map((s: any) => ({
-          name: s.name,
-          parent: s.parent_id,
-          id: s.id,
-        })),
-      );
-
       const response = await client.get("/.config/api/streams", {
         headers: {
           Authorization: `Bearer ${authToken}`,
@@ -136,8 +121,6 @@ describe("Streams API", () => {
 
       // Should include all streams including .config ones
       const paths = data.streams.map((s: any) => s.path);
-      console.log("API returned paths:", paths);
-      console.log("Stream details:", data.streams.slice(0, 3));
       expect(paths).to.include("/.config");
       expect(paths).to.include("/.config/owner");
       // .config/settings may not exist if not created explicitly

--- a/node/packages/webpods/package-lock.json
+++ b/node/packages/webpods/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "license": "MIT",
       "dependencies": {
         "@ory/hydra-client": "^2.4.0-alpha.1",

--- a/node/packages/webpods/package.json
+++ b/node/packages/webpods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpods",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "Append-only log service with OAuth authentication",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Removed all debug console.log statements from test files to have cleaner test output. Affected test files:
- streams-api.test.ts: Removed DB streams and API paths logging
- records.test.ts: Removed list/streams command output logging
- verify.test.ts: Removed verify command output logging

🤖 Generated with [Claude Code](https://claude.ai/code)