### PR TITLE
refactor: Restructure CLI to consistent resource-action pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,56 @@ For troubleshooting common issues, refer to:
 - Content type handling
 - Hash chain verification
 
+## CLI Command Structure
+
+The CLI follows a consistent `<resource> <action>` pattern for all commands:
+
+### Resource Groups
+
+- **auth**: Authentication management (`login`, `logout`, `info`)
+- **pod**: Pod management (`create`, `list`, `delete`, `info`, `transfer`)
+- **stream**: Stream management (`create`, `delete`, `list`)
+- **record**: Record operations (`write`, `read`, `delete`, `list`, `verify`)
+- **permission**: Permission management (`grant`, `revoke`, `list`)
+- **link**: Link management (`set`, `list`, `remove`)
+- **oauth**: OAuth client management (`register`, `list`, `info`, `delete`)
+- **limit**: Rate limit information (`info`)
+- **config**: Configuration management
+
+### Command Examples
+
+```bash
+# Authentication
+podctl auth login
+podctl auth info
+podctl auth logout
+
+# Pod operations
+podctl pod create my-pod
+podctl pod list
+podctl pod delete my-pod --force
+podctl pod transfer my-pod new-owner-id --force
+
+# Stream operations
+podctl stream create my-pod my-stream --access public
+podctl stream list my-pod
+podctl stream delete my-pod my-stream --force
+
+# Record operations
+podctl record write my-pod my-stream record-name "data"
+podctl record read my-pod my-stream record-name
+podctl record delete my-pod my-stream record-name --force
+podctl record list my-pod my-stream
+podctl record verify my-pod my-stream --check-integrity
+
+# Permission operations
+podctl permission grant my-pod my-stream user-id
+podctl permission revoke my-pod my-stream user-id
+podctl permission list my-pod my-stream
+```
+
+This structure ensures consistency and scalability across all CLI commands.
+
 ## Additional Resources
 
 - `/CODING-STANDARDS.md` - Detailed coding conventions

--- a/node/packages/webpods-cli-tests/src/tests/auth.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/auth.test.ts
@@ -34,7 +34,7 @@ describe("CLI Auth Commands", function () {
 
   describe("login command", () => {
     it("should display login instructions", async () => {
-      const result = await cli.exec(["login"]);
+      const result = await cli.exec(["auth", "login"]);
 
       if (result.exitCode !== 0) {
         console.error("CLI failed with exit code:", result.exitCode);
@@ -62,7 +62,7 @@ describe("CLI Auth Commands", function () {
 
   describe("whoami command", () => {
     it("should show user info when authenticated", async () => {
-      const result = await cli.exec(["whoami", "--format", "json"], {
+      const result = await cli.exec(["auth", "info", "--format", "json"], {
         token: testToken,
       });
 
@@ -73,7 +73,7 @@ describe("CLI Auth Commands", function () {
     });
 
     it("should fail when not authenticated", async () => {
-      const result = await cli.exec(["whoami", "--format", "json"]);
+      const result = await cli.exec(["auth", "info", "--format", "json"]);
 
       expect(result.exitCode).to.not.equal(0);
       expect(result.stderr).to.include("Not authenticated");
@@ -104,7 +104,7 @@ describe("CLI Auth Commands", function () {
   describe("logout command", () => {
     it("should clear stored token", async () => {
       await cli.setToken(testToken);
-      const result = await cli.exec(["logout"]);
+      const result = await cli.exec(["auth", "logout"]);
 
       expect(result.exitCode).to.equal(0);
       expect(result.stdout).to.include("Logged out successfully");

--- a/node/packages/webpods-cli-tests/src/tests/grant-revoke.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/grant-revoke.test.ts
@@ -68,7 +68,14 @@ describe("CLI Grant/Revoke Commands", function () {
   describe("grant command", () => {
     it("should grant read permission to a user", async () => {
       const result = await cli.exec(
-        ["grant", testPodName, "/team-permissions", otherUserId, "--read"],
+        [
+          "permission",
+          "grant",
+          testPodName,
+          "/team-permissions",
+          otherUserId,
+          "--read",
+        ],
         {
           token: testToken,
         },
@@ -81,7 +88,14 @@ describe("CLI Grant/Revoke Commands", function () {
 
     it("should grant write permission to a user", async () => {
       const result = await cli.exec(
-        ["grant", testPodName, "/team-permissions", otherUserId, "--write"],
+        [
+          "permission",
+          "grant",
+          testPodName,
+          "/team-permissions",
+          otherUserId,
+          "--write",
+        ],
         {
           token: testToken,
         },
@@ -94,6 +108,7 @@ describe("CLI Grant/Revoke Commands", function () {
     it("should grant both read and write permissions", async () => {
       const result = await cli.exec(
         [
+          "permission",
           "grant",
           testPodName,
           "team-permissions",
@@ -112,7 +127,7 @@ describe("CLI Grant/Revoke Commands", function () {
 
     it("should require at least one permission flag", async () => {
       const result = await cli.exec(
-        ["grant", testPodName, "/team-permissions", otherUserId],
+        ["permission", "grant", testPodName, "/team-permissions", otherUserId],
         {
           token: testToken,
         },
@@ -124,6 +139,7 @@ describe("CLI Grant/Revoke Commands", function () {
 
     it("should require authentication", async () => {
       const result = await cli.exec([
+        "permission",
         "grant",
         testPodName,
         "team-permissions",
@@ -141,6 +157,7 @@ describe("CLI Grant/Revoke Commands", function () {
       // First grant some permissions
       await cli.exec(
         [
+          "permission",
           "grant",
           testPodName,
           "team-permissions",
@@ -156,7 +173,7 @@ describe("CLI Grant/Revoke Commands", function () {
 
     it("should revoke all permissions from a user", async () => {
       const result = await cli.exec(
-        ["revoke", testPodName, "/team-permissions", otherUserId],
+        ["permission", "revoke", testPodName, "/team-permissions", otherUserId],
         {
           token: testToken,
         },
@@ -169,6 +186,7 @@ describe("CLI Grant/Revoke Commands", function () {
 
     it("should require authentication", async () => {
       const result = await cli.exec([
+        "permission",
         "revoke",
         testPodName,
         "team-permissions",

--- a/node/packages/webpods-cli-tests/src/tests/links.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/links.test.ts
@@ -54,7 +54,7 @@ describe("CLI Links Commands", function () {
   describe("links set command", () => {
     it("should set a link for a pod", async () => {
       const result = await cli.exec(
-        ["links", "set", testPodName, "/about", "pages/about"],
+        ["link", "set", testPodName, "/about", "pages/about"],
         {
           token: testToken,
         },
@@ -66,7 +66,7 @@ describe("CLI Links Commands", function () {
 
     it("should set multiple links", async () => {
       const result1 = await cli.exec(
-        ["links", "set", testPodName, "/", "homepage/index"],
+        ["link", "set", testPodName, "/", "homepage/index"],
         {
           token: testToken,
         },
@@ -74,7 +74,7 @@ describe("CLI Links Commands", function () {
       expect(result1.exitCode).to.equal(0);
 
       const result2 = await cli.exec(
-        ["links", "set", testPodName, "/blog", "blog/posts?unique=true"],
+        ["link", "set", testPodName, "/blog", "blog/posts?unique=true"],
         {
           token: testToken,
         },
@@ -84,7 +84,7 @@ describe("CLI Links Commands", function () {
 
     it("should require authentication", async () => {
       const result = await cli.exec([
-        "links",
+        "link",
         "set",
         testPodName,
         "/about",
@@ -99,19 +99,19 @@ describe("CLI Links Commands", function () {
   describe("links list command", () => {
     beforeEach(async () => {
       // Set up some test links
-      await cli.exec(["links", "set", testPodName, "/", "homepage/index"], {
+      await cli.exec(["link", "set", testPodName, "/", "homepage/index"], {
         token: testToken,
       });
-      await cli.exec(["links", "set", testPodName, "/about", "pages/about"], {
+      await cli.exec(["link", "set", testPodName, "/about", "pages/about"], {
         token: testToken,
       });
-      await cli.exec(["links", "set", testPodName, "/blog", "blog/posts"], {
+      await cli.exec(["link", "set", testPodName, "/blog", "blog/posts"], {
         token: testToken,
       });
     });
 
     it("should list all links for a pod", async () => {
-      const result = await cli.exec(["links", "list", testPodName], {
+      const result = await cli.exec(["link", "list", testPodName], {
         token: testToken,
       });
 
@@ -124,7 +124,7 @@ describe("CLI Links Commands", function () {
 
     it("should output in JSON format", async () => {
       const result = await cli.exec(
-        ["links", "list", testPodName, "--format", "json"],
+        ["link", "list", testPodName, "--format", "json"],
         {
           token: testToken,
         },
@@ -144,7 +144,7 @@ describe("CLI Links Commands", function () {
           name: emptyPodName,
         });
 
-      const result = await cli.exec(["links", "list", emptyPodName], {
+      const result = await cli.exec(["link", "list", emptyPodName], {
         token: testToken,
       });
 
@@ -156,27 +156,24 @@ describe("CLI Links Commands", function () {
   describe("links remove command", () => {
     beforeEach(async () => {
       // Set up test links
-      await cli.exec(["links", "set", testPodName, "/about", "pages/about"], {
+      await cli.exec(["link", "set", testPodName, "/about", "pages/about"], {
         token: testToken,
       });
-      await cli.exec(["links", "set", testPodName, "/blog", "blog/posts"], {
+      await cli.exec(["link", "set", testPodName, "/blog", "blog/posts"], {
         token: testToken,
       });
     });
 
     it("should remove a specific link", async () => {
-      const result = await cli.exec(
-        ["links", "remove", testPodName, "/about"],
-        {
-          token: testToken,
-        },
-      );
+      const result = await cli.exec(["link", "remove", testPodName, "/about"], {
+        token: testToken,
+      });
 
       expect(result.exitCode).to.equal(0);
       expect(result.stdout).to.include("Link removed: /about");
 
       // Verify link was removed
-      const listResult = await cli.exec(["links", "list", testPodName], {
+      const listResult = await cli.exec(["link", "list", testPodName], {
         token: testToken,
       });
       expect(listResult.stdout).to.not.include("/about → pages/about");
@@ -185,7 +182,7 @@ describe("CLI Links Commands", function () {
 
     it("should handle removing non-existent link", async () => {
       const result = await cli.exec(
-        ["links", "remove", testPodName, "/nonexistent"],
+        ["link", "remove", testPodName, "/nonexistent"],
         {
           token: testToken,
         },
@@ -197,7 +194,7 @@ describe("CLI Links Commands", function () {
     });
 
     it("should require authentication", async () => {
-      const result = await cli.exec(["links", "remove", testPodName, "/about"]);
+      const result = await cli.exec(["link", "remove", testPodName, "/about"]);
 
       expect(result.exitCode).to.not.equal(0);
       expect(result.stderr).to.include("Not authenticated");

--- a/node/packages/webpods-cli-tests/src/tests/pods.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/pods.test.ts
@@ -42,7 +42,7 @@ describe("CLI Pod Commands", function () {
     it("should create a new pod", async () => {
       // Skip for now - pod creation in WebPods is implicit when writing
       // The CLI needs a different approach or the server needs an explicit API
-      const result = await cli.exec(["create", "test-pod"], {
+      const result = await cli.exec(["pod", "create", "test-pod"], {
         token: testToken,
       });
 
@@ -74,7 +74,7 @@ describe("CLI Pod Commands", function () {
     });
 
     it("should reject invalid pod names", async () => {
-      const result = await cli.exec(["create", "Test-Pod"], {
+      const result = await cli.exec(["pod", "create", "Test-Pod"], {
         token: testToken,
       });
 
@@ -84,10 +84,10 @@ describe("CLI Pod Commands", function () {
 
     it("should reject duplicate pod names", async () => {
       // Create first pod
-      await cli.exec(["create", "test-pod"], { token: testToken });
+      await cli.exec(["pod", "create", "test-pod"], { token: testToken });
 
       // Try to create duplicate
-      const result = await cli.exec(["create", "test-pod"], {
+      const result = await cli.exec(["pod", "create", "test-pod"], {
         token: testToken,
       });
 
@@ -96,7 +96,7 @@ describe("CLI Pod Commands", function () {
     });
 
     it("should require authentication", async () => {
-      const result = await cli.exec(["create", "test-pod"]);
+      const result = await cli.exec(["pod", "create", "test-pod"]);
 
       expect(result.exitCode).to.not.equal(0);
       expect(result.stderr).to.include("Authentication required");
@@ -125,7 +125,7 @@ describe("CLI Pod Commands", function () {
     });
 
     it("should list all user pods", async () => {
-      const result = await cli.exec(["list", "--format", "json"], {
+      const result = await cli.exec(["pod", "list", "--format", "json"], {
         token: testToken,
       });
 
@@ -139,7 +139,7 @@ describe("CLI Pod Commands", function () {
     it("should show message when no pods exist", async () => {
       await resetCliTestDb();
 
-      const result = await cli.exec(["list"], {
+      const result = await cli.exec(["pod", "list"], {
         token: testToken,
       });
 
@@ -150,14 +150,14 @@ describe("CLI Pod Commands", function () {
 
     it("should support different output formats", async () => {
       // CSV format
-      const csvResult = await cli.exec(["list", "--format", "csv"], {
+      const csvResult = await cli.exec(["pod", "list", "--format", "csv"], {
         token: testToken,
       });
       expect(csvResult.exitCode).to.equal(0);
       expect(csvResult.stdout).to.include("name,id,created_at");
 
       // YAML format
-      const yamlResult = await cli.exec(["list", "--format", "yaml"], {
+      const yamlResult = await cli.exec(["pod", "list", "--format", "yaml"], {
         token: testToken,
       });
       expect(yamlResult.exitCode).to.equal(0);
@@ -194,9 +194,12 @@ describe("CLI Pod Commands", function () {
         testUser.userId,
       );
 
-      const result = await cli.exec(["info", "test-pod", "--format", "json"], {
-        token: testToken,
-      });
+      const result = await cli.exec(
+        ["pod", "info", "test-pod", "--format", "json"],
+        {
+          token: testToken,
+        },
+      );
 
       expect(result.exitCode).to.equal(0);
       const info = cli.parseJson(result.stdout);
@@ -207,7 +210,7 @@ describe("CLI Pod Commands", function () {
     });
 
     it("should fail for non-existent pod", async () => {
-      const result = await cli.exec(["info", "no-such-pod"], {
+      const result = await cli.exec(["pod", "info", "no-such-pod"], {
         token: testToken,
       });
 
@@ -235,7 +238,7 @@ describe("CLI Pod Commands", function () {
     });
 
     it("should delete a pod with force flag", async () => {
-      const result = await cli.exec(["delete", "test-pod", "--force"], {
+      const result = await cli.exec(["pod", "delete", "test-pod", "--force"], {
         token: testToken,
       });
 
@@ -252,7 +255,7 @@ describe("CLI Pod Commands", function () {
     });
 
     it("should show warning without force flag", async () => {
-      const result = await cli.exec(["delete", "test-pod"], {
+      const result = await cli.exec(["pod", "delete", "test-pod"], {
         token: testToken,
       });
 
@@ -293,7 +296,7 @@ describe("CLI Pod Commands", function () {
         );
       const otherToken = cli.createTestToken(otherUserId, "other@example.com");
 
-      const result = await cli.exec(["delete", "test-pod", "--force"], {
+      const result = await cli.exec(["pod", "delete", "test-pod", "--force"], {
         token: otherToken,
       });
 

--- a/node/packages/webpods-cli-tests/src/tests/profiles.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/profiles.test.ts
@@ -277,7 +277,12 @@ describe("CLI Profile Management", () => {
     });
 
     it("should error on non-existent profile", async () => {
-      const result = await cli.exec(["pods", "--profile", "nonexistent"]);
+      const result = await cli.exec([
+        "pod",
+        "list",
+        "--profile",
+        "nonexistent",
+      ]);
 
       expect(result.exitCode).to.not.equal(0);
       expect(result.stderr).to.include("Profile 'nonexistent' not found");
@@ -326,7 +331,7 @@ describe("CLI Profile Management", () => {
         "../../../webpods-cli/dist/index.js",
       );
 
-      const child = spawn("node", [cliPath, "login"], { env });
+      const child = spawn("node", [cliPath, "auth", "login"], { env });
 
       let stdout = "";
       child.stdout.on("data", (data: Buffer) => {

--- a/node/packages/webpods-cli-tests/src/tests/records.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/records.test.ts
@@ -69,6 +69,7 @@ describe("CLI Record Commands", function () {
 
       const result = await cli.exec(
         [
+          "record",
           "write",
           testPodName,
           "test-stream",
@@ -116,6 +117,7 @@ describe("CLI Record Commands", function () {
 
       const result = await cli.exec(
         [
+          "record",
           "write",
           testPodName,
           "test-stream",
@@ -149,6 +151,7 @@ describe("CLI Record Commands", function () {
       // Write with permission flag - this updates the stream permission to public
       const result = await cli.exec(
         [
+          "record",
           "write",
           testPodName,
           "test-stream",
@@ -208,7 +211,7 @@ describe("CLI Record Commands", function () {
 
     it("should read a specific record by name", async () => {
       const result = await cli.exec(
-        ["read", testPodName, "test-stream", "record1"],
+        ["record", "read", testPodName, "test-stream", "record1"],
         {
           token: testToken,
         },
@@ -222,9 +225,12 @@ describe("CLI Record Commands", function () {
 
     it("should read latest record without name", async () => {
       // Without a name, the CLI must specify an index
-      const result = await cli.exec(["read", testPodName, "test-stream"], {
-        token: testToken,
-      });
+      const result = await cli.exec(
+        ["record", "read", testPodName, "test-stream"],
+        {
+          token: testToken,
+        },
+      );
 
       // Should fail because neither index nor name is provided
       expect(result.exitCode).to.not.equal(0);
@@ -235,7 +241,7 @@ describe("CLI Record Commands", function () {
 
     it("should read by index", async () => {
       const result = await cli.exec(
-        ["read", testPodName, "test-stream", "--index", "0"],
+        ["record", "read", testPodName, "test-stream", "--index", "0"],
         {
           token: testToken,
         },
@@ -249,6 +255,7 @@ describe("CLI Record Commands", function () {
 
     it("should require authentication for private streams", async () => {
       const result = await cli.exec([
+        "record",
         "read",
         testPodName,
         "test-stream",
@@ -393,9 +400,12 @@ describe("CLI Record Commands", function () {
       });
 
       // Use --quiet=false explicitly to ensure output
-      const result = await cli.exec(["streams", testPodName, "--quiet=false"], {
-        token: testToken,
-      });
+      const result = await cli.exec(
+        ["stream", "list", testPodName, "--quiet=false"],
+        {
+          token: testToken,
+        },
+      );
 
       // Check the output exists first
       expect(result.exitCode).to.equal(0);

--- a/node/packages/webpods-cli-tests/src/tests/schema.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/schema.test.ts
@@ -59,7 +59,7 @@ describe("CLI Schema Commands", () => {
 
       // Enable schema
       const result = await cli.exec(
-        ["schema", "enable", `${testPodName}/blog/posts`, schemaFile],
+        ["schema", "enable", testPodName, "blog/posts", schemaFile],
         {
           token: testToken,
         },
@@ -91,7 +91,8 @@ describe("CLI Schema Commands", () => {
         [
           "schema",
           "enable",
-          `${testPodName}/api/data`,
+          testPodName,
+          "api/data",
           schemaFile,
           "--mode",
           "permissive",
@@ -120,7 +121,7 @@ describe("CLI Schema Commands", () => {
       await fs.writeFile(invalidFile, "not valid json");
 
       const result = await cli.exec(
-        ["schema", "enable", `${testPodName}/test`, invalidFile],
+        ["schema", "enable", testPodName, "test", invalidFile],
         {
           token: testToken,
         },
@@ -132,7 +133,7 @@ describe("CLI Schema Commands", () => {
 
     it("should fail with non-existent schema file", async () => {
       const result = await cli.exec(
-        ["schema", "enable", `${testPodName}/test`, "/does/not/exist.json"],
+        ["schema", "enable", testPodName, "test", "/does/not/exist.json"],
         {
           token: testToken,
         },
@@ -147,7 +148,7 @@ describe("CLI Schema Commands", () => {
       await fs.writeFile(schemaFile, JSON.stringify({ type: "object" }));
 
       const result = await cli.exec(
-        ["schema", "enable", `${testPodName}/test`, schemaFile],
+        ["schema", "enable", testPodName, "test", schemaFile],
         {
           // No token provided
         },
@@ -170,13 +171,13 @@ describe("CLI Schema Commands", () => {
         }),
       );
 
-      await cli.exec(["schema", "enable", `${testPodName}/users`, schemaFile], {
+      await cli.exec(["schema", "enable", testPodName, "users", schemaFile], {
         token: testToken,
       });
 
       // Now disable it
       const result = await cli.exec(
-        ["schema", "disable", `${testPodName}/users`],
+        ["schema", "disable", testPodName, "users"],
         {
           token: testToken,
         },
@@ -202,7 +203,7 @@ describe("CLI Schema Commands", () => {
 
     it("should work even if no schema was previously set", async () => {
       const result = await cli.exec(
-        ["schema", "disable", `${testPodName}/newstream`],
+        ["schema", "disable", testPodName, "newstream"],
         {
           token: testToken,
         },
@@ -214,7 +215,7 @@ describe("CLI Schema Commands", () => {
 
     it("should require authentication", async () => {
       const result = await cli.exec(
-        ["schema", "disable", `${testPodName}/test`],
+        ["schema", "disable", testPodName, "test"],
         {
           // No token provided
         },
@@ -240,7 +241,7 @@ describe("CLI Schema Commands", () => {
       await fs.writeFile(schemaFile, JSON.stringify(schema));
 
       const enableResult = await cli.exec(
-        ["schema", "enable", `${testPodName}/people`, schemaFile],
+        ["schema", "enable", testPodName, "people", schemaFile],
         {
           token: testToken,
         },
@@ -250,6 +251,7 @@ describe("CLI Schema Commands", () => {
       // Valid data should succeed
       let result = await cli.exec(
         [
+          "record",
           "write",
           testPodName,
           "people",
@@ -265,6 +267,7 @@ describe("CLI Schema Commands", () => {
       // Invalid data should fail - write to the same stream with a different name
       result = await cli.exec(
         [
+          "record",
           "write",
           testPodName,
           "people",
@@ -293,19 +296,26 @@ describe("CLI Schema Commands", () => {
       );
 
       await cli.exec(
-        ["schema", "enable", `${testPodName}/flexible`, schemaFile],
+        ["schema", "enable", testPodName, "flexible", schemaFile],
         {
           token: testToken,
         },
       );
 
-      await cli.exec(["schema", "disable", `${testPodName}/flexible`], {
+      await cli.exec(["schema", "disable", testPodName, "flexible"], {
         token: testToken,
       });
 
       // Any data should now work
       const result = await cli.exec(
-        ["write", testPodName, "flexible", "test-record", "any random content"],
+        [
+          "record",
+          "write",
+          testPodName,
+          "flexible",
+          "test-record",
+          "any random content",
+        ],
         {
           token: testToken,
         },

--- a/node/packages/webpods-cli-tests/src/tests/transfer.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/transfer.test.ts
@@ -94,9 +94,12 @@ describe("CLI Transfer Command", function () {
 
   describe("transfer command", () => {
     it("should show warning without --force flag", async () => {
-      const result = await cli.exec(["transfer", testPodName, newOwnerId], {
-        token: testToken,
-      });
+      const result = await cli.exec(
+        ["pod", "transfer", testPodName, newOwnerId],
+        {
+          token: testToken,
+        },
+      );
 
       expect(result.exitCode).to.equal(0);
       expect(result.stdout).to.include("WARNING");
@@ -128,7 +131,7 @@ describe("CLI Transfer Command", function () {
 
     it("should transfer ownership with --force flag", async () => {
       const result = await cli.exec(
-        ["transfer", testPodName, newOwnerId, "--force"],
+        ["pod", "transfer", testPodName, newOwnerId, "--force"],
         {
           token: testToken,
         },
@@ -158,7 +161,7 @@ describe("CLI Transfer Command", function () {
       const otherToken = cli.createTestToken(otherUserId, "other@example.com");
 
       const result = await cli.exec(
-        ["transfer", testPodName, newOwnerId, "--force"],
+        ["pod", "transfer", testPodName, newOwnerId, "--force"],
         {
           token: otherToken,
         },
@@ -170,6 +173,7 @@ describe("CLI Transfer Command", function () {
 
     it("should require authentication", async () => {
       const result = await cli.exec([
+        "pod",
         "transfer",
         testPodName,
         newOwnerId,
@@ -184,7 +188,7 @@ describe("CLI Transfer Command", function () {
       const nonExistentUser = randomUUID();
 
       const result = await cli.exec(
-        ["transfer", testPodName, nonExistentUser, "--force"],
+        ["pod", "transfer", testPodName, nonExistentUser, "--force"],
         {
           token: testToken,
         },
@@ -200,7 +204,7 @@ describe("CLI Transfer Command", function () {
     it("should prevent old owner from accessing pod after transfer", async () => {
       // First transfer the pod
       const transferResult = await cli.exec(
-        ["transfer", testPodName, newOwnerId, "--force"],
+        ["pod", "transfer", testPodName, newOwnerId, "--force"],
         {
           token: testToken,
         },
@@ -211,7 +215,7 @@ describe("CLI Transfer Command", function () {
       // Try to write to existing stream with old owner's token
       // This should fail since they're no longer the pod owner
       const existingStreamResult = await cli.exec(
-        ["write", testPodName, "/test-stream", "test-record", "data"],
+        ["record", "write", testPodName, "/test-stream", "test-record", "data"],
         {
           token: testToken,
         },
@@ -225,6 +229,7 @@ describe("CLI Transfer Command", function () {
       // and the old owner can't create streams anymore
       const newStreamResult = await cli.exec(
         [
+          "record",
           "write",
           testPodName,
           "new-stream-after-transfer",
@@ -250,7 +255,7 @@ describe("CLI Transfer Command", function () {
 
     it("should allow new owner to access pod after transfer", async () => {
       // First transfer the pod
-      await cli.exec(["transfer", testPodName, newOwnerId, "--force"], {
+      await cli.exec(["pod", "transfer", testPodName, newOwnerId, "--force"], {
         token: testToken,
       });
 
@@ -268,7 +273,14 @@ describe("CLI Transfer Command", function () {
 
       // Try to write to the stream with new owner's token
       const result = await cli.exec(
-        ["write", testPodName, "/new-owner-stream", "test-record", "data"],
+        [
+          "record",
+          "write",
+          testPodName,
+          "/new-owner-stream",
+          "test-record",
+          "data",
+        ],
         {
           token: newOwnerToken,
         },

--- a/node/packages/webpods-cli-tests/src/tests/verify.test.ts
+++ b/node/packages/webpods-cli-tests/src/tests/verify.test.ts
@@ -90,9 +90,12 @@ describe("CLI Verify Command", function () {
 
   describe("verify command - summary", () => {
     it("should show stream summary by default", async () => {
-      const result = await cli.exec(["verify", testPodName, "/test-stream"], {
-        token: testToken,
-      });
+      const result = await cli.exec(
+        ["record", "verify", testPodName, "/test-stream"],
+        {
+          token: testToken,
+        },
+      );
 
       expect(result.exitCode).to.equal(0);
       expect(result.stdout).to.include("Stream '/test-stream' summary:");
@@ -111,9 +114,12 @@ describe("CLI Verify Command", function () {
         accessPermission: "private",
       });
 
-      const result = await cli.exec(["verify", testPodName, "/empty-stream"], {
-        token: testToken,
-      });
+      const result = await cli.exec(
+        ["record", "verify", testPodName, "/empty-stream"],
+        {
+          token: testToken,
+        },
+      );
 
       expect(result.exitCode).to.equal(0);
       expect(result.stdout).to.include("Stream '/empty-stream' is empty");
@@ -123,7 +129,7 @@ describe("CLI Verify Command", function () {
   describe("verify command - show chain", () => {
     it("should display full hash chain with --show-chain", async () => {
       const result = await cli.exec(
-        ["verify", testPodName, "/test-stream", "--show-chain"],
+        ["record", "verify", testPodName, "/test-stream", "--show-chain"],
         {
           token: testToken,
         },
@@ -147,7 +153,7 @@ describe("CLI Verify Command", function () {
   describe("verify command - check integrity", () => {
     it("should verify valid hash chain", async () => {
       const result = await cli.exec(
-        ["verify", testPodName, "/test-stream", "--check-integrity"],
+        ["record", "verify", testPodName, "/test-stream", "--check-integrity"],
         {
           token: testToken,
         },
@@ -179,7 +185,7 @@ describe("CLI Verify Command", function () {
         );
 
       const result = await cli.exec(
-        ["verify", testPodName, "/test-stream", "--check-integrity"],
+        ["record", "verify", testPodName, "/test-stream", "--check-integrity"],
         {
           token: testToken,
         },
@@ -208,7 +214,7 @@ describe("CLI Verify Command", function () {
         );
 
       const result = await cli.exec(
-        ["verify", testPodName, "/test-stream", "--check-integrity"],
+        ["record", "verify", testPodName, "/test-stream", "--check-integrity"],
         {
           token: testToken,
         },
@@ -223,7 +229,12 @@ describe("CLI Verify Command", function () {
 
   describe("verify command - permissions", () => {
     it("should require authentication for private streams", async () => {
-      const result = await cli.exec(["verify", testPodName, "/test-stream"]);
+      const result = await cli.exec([
+        "record",
+        "verify",
+        testPodName,
+        "/test-stream",
+      ]);
 
       expect(result.exitCode).to.not.equal(0);
       // The server returns an error when trying to fetch without auth
@@ -252,7 +263,12 @@ describe("CLI Verify Command", function () {
         index: 0,
       });
 
-      const result = await cli.exec(["verify", testPodName, "/public-stream"]);
+      const result = await cli.exec([
+        "record",
+        "verify",
+        testPodName,
+        "/public-stream",
+      ]);
 
       // Should work without authentication for public streams
       expect(result.stdout).to.include("Stream '/public-stream' summary:");

--- a/node/packages/webpods-cli/README.md
+++ b/node/packages/webpods-cli/README.md
@@ -16,20 +16,17 @@ npx webpods-cli
 
 ```bash
 # 1. Authenticate with WebPods
-pod login
+podctl login
 # Follow the instructions to get your token
 
-# 2. Set your token
-pod token set <your-token>
+# 2. Create your first pod
+podctl pod create my-pod
 
-# 3. Create your first pod
-pod create my-pod
+# 3. Write data to a stream
+podctl record write my-pod notes/today "My first note"
 
-# 4. Write data to a stream
-pod write my-pod notes/today "My first note"
-
-# 5. Read it back
-pod read my-pod notes/today
+# 4. Read it back
+podctl record read my-pod notes/today
 ```
 
 ## Authentication
@@ -40,23 +37,17 @@ Start the OAuth authentication flow:
 
 ```bash
 # Show all available OAuth providers for the current server
-pod login
+podctl login
+# Or use the full command
+podctl auth login
 ```
 
 This will print login URL(s) to visit in your browser. After authenticating, copy the token from the success page.
 
-### Set Token
-
-Store your authentication token:
-
-```bash
-pod token set <token>
-```
-
 ### Check Current User
 
 ```bash
-pod whoami
+podctl auth info
 ```
 
 ### Logout
@@ -64,15 +55,19 @@ pod whoami
 Clear stored authentication:
 
 ```bash
-pod logout
+podctl logout
+# Or use the full command
+podctl auth logout
 ```
+
+**Note:** `podctl login` and `podctl logout` are convenient aliases for `podctl auth login` and `podctl auth logout`.
 
 ## Pod Management
 
 ### Create a Pod
 
 ```bash
-pod create <name>
+podctl pod create <name>
 ```
 
 Pod names must be lowercase letters, numbers, and hyphens only.
@@ -80,127 +75,148 @@ Pod names must be lowercase letters, numbers, and hyphens only.
 ### List Your Pods
 
 ```bash
-pod list [--format json|yaml|table|csv]
+podctl pod list [--format json|yaml|table|csv]
 ```
 
 ### Get Pod Information
 
 ```bash
-pod info <pod-name>
+podctl pod info <pod-name>
 ```
 
 ### Delete a Pod
 
 ```bash
-pod delete <pod-name> [--force]
+podctl pod delete <pod-name> [--force]
 ```
 
 ⚠️ This will delete all data in the pod!
 
+### Transfer Pod Ownership
+
+```bash
+podctl pod transfer <pod-name> <new-owner-id> [--force]
+```
+
+⚠️ This will permanently transfer ownership of the pod!
+
 ## Working with Streams and Records
 
-### Write Data
+### Stream Management
+
+#### Create Stream
+
+```bash
+podctl stream create <pod> <stream> [--access public|private|/permission-path]
+```
+
+#### List Streams
+
+```bash
+podctl stream list <pod>
+```
+
+#### Delete Stream
+
+```bash
+podctl stream delete <pod> <stream> [--force]
+```
+
+### Record Management
+
+#### Write Data
 
 Write data to a stream record:
 
 ```bash
 # Write inline data
-pod write <pod> <stream> <record-name> '{"data": "value"}'
+podctl record write <pod> <stream> <record-name> '{"data": "value"}'
 
 # Write from file
-pod write <pod> <stream> <record-name> --file data.json
+podctl record write <pod> <stream> <record-name> --file data.json
 
 # Set permissions (public, private, or /permission-stream)
-pod write <pod> <stream> <record-name> '{"data": "value"}' --permission public
+podctl record write <pod> <stream> <record-name> '{"data": "value"}' --permission public
 ```
 
-### Read Data
+#### Read Data
 
 ```bash
 # Read specific record by name
-pod read <pod> <stream> <record-name>
-
-# Read latest record in stream
-pod read <pod> <stream>
+podctl record read <pod> <stream> <record-name>
 
 # Read by index (0-based)
-pod read <pod> <stream> --index 0
+podctl record read <pod> <stream> --index 0
 
 # Read by negative index (-1 is latest)
-pod read <pod> <stream> --index -1
+podctl record read <pod> <stream> --index -1
 
 # Save to file
-pod read <pod> <stream> <record-name> --output data.json
+podctl record read <pod> <stream> <record-name> --output data.json
 ```
 
-### List Records
+#### Delete Record
+
+```bash
+podctl record delete <pod> <stream> <record-name> [--force]
+```
+
+#### List Records
 
 ```bash
 # List all records
-pod record list <pod> <stream>
+podctl record list <pod> <stream>
 
 # Limit results
-pod record list <pod> <stream> --limit 10
+podctl record list <pod> <stream> --limit 10
 
 # Pagination
-pod record list <pod> <stream> --after 50
+podctl record list <pod> <stream> --after 50
 
 # Show only unique named records (latest version of each)
-pod record list <pod> <stream> --unique
+podctl record list <pod> <stream> --unique
 
 # Different output formats
-pod record list <pod> <stream> --format json
+podctl record list <pod> <stream> --format json
 ```
 
-### List Streams
+#### Verify Stream Integrity
 
 ```bash
-pod stream list <pod>
-```
+# Show stream summary
+podctl record verify <pod> <stream>
 
-### Delete Stream
+# Show full hash chain
+podctl record verify <pod> <stream> --show-chain
 
-```bash
-pod stream delete <pod> <stream> [--force]
+# Check integrity
+podctl record verify <pod> <stream> --check-integrity
 ```
 
 ## Permissions
 
 WebPods supports three permission modes:
 
-- `private` - Only the pod owner can access
+- `private` - Only the podctl owner can access
 - `public` - Anyone can read (write still requires auth)
 - `/stream-path` - Permission controlled by another stream
-
-### View Permissions
-
-```bash
-pod permissions <pod> <stream> view
-```
-
-### Set Permission Mode
-
-```bash
-pod permissions <pod> <stream> set --mode public
-pod permissions <pod> <stream> set --mode /permissions/readers
-```
 
 ### Grant User Access
 
 ```bash
-pod permissions <pod> <stream> grant --user <user-id>
+podctl permission grant <pod> <stream> <user-id>
 ```
 
 ### Revoke User Access
 
 ```bash
-pod permissions <pod> <stream> revoke --user <user-id>
+podctl permission revoke <pod> <stream> <user-id>
 ```
 
 ### List Permission Records
 
 ```bash
-pod permissions <pod> <stream> list
+podctl permission list <pod> <stream>
 ```
 
 ## OAuth Client Management
@@ -208,45 +224,89 @@ pod permissions <pod> <stream> list
 ### Register OAuth Client
 
 ```bash
-pod oauth register --name "My App" --redirect "https://myapp.com/callback" [--pods pod1,pod2]
+podctl oauth register --name "My App" --redirect "https://myapp.com/callback" [--pods pod1,pod2]
 ```
 
 ### List Your OAuth Clients
 
 ```bash
-pod oauth list
+podctl oauth list
 ```
 
 ### Get Client Details
 
 ```bash
-pod oauth info <client-id>
+podctl oauth info <client-id>
 ```
 
 ### Delete OAuth Client
 
 ```bash
-pod oauth delete <client-id> [--force]
+podctl oauth delete <client-id> [--force]
+```
+
+## Links
+
+### Set a Link
+
+```bash
+podctl link set <key> <target-pod> <target-stream>
+```
+
+### List Links
+
+```bash
+podctl link list
+```
+
+### Remove a Link
+
+```bash
+podctl link remove <key>
+```
+
+## Rate Limits
+
+### View Rate Limit Information
+
+```bash
+podctl limit info
 ```
 
 ## Configuration
 
-### View Configuration
+### View Current Configuration
 
 ```bash
-pod config
+podctl config
 ```
 
-### Set Server URL
+This shows the current profile settings including server URL, authentication status, and preferences.
+
+### Managing Server URLs
+
+Server URLs are managed through profiles:
 
 ```bash
-pod config server https://api.webpods.org
+# Add a new profile with a different server
+podctl profile add myserver --server https://my-webpods.com
+
+# Switch to that profile
+podctl profile use myserver
+
+# List all profiles
+podctl profile list
 ```
 
-### Set Configuration Value
+### Set Configuration Values
 
 ```bash
-pod config <key> <value>
+# Set output format or default pod
+podctl config <key> <value>
+
+# Valid keys: outputFormat, defaultPod
+podctl config outputFormat json
+podctl config defaultPod my-main-pod
 ```
 
 ## Global Options
@@ -267,43 +327,47 @@ All commands support these options:
 
 ```bash
 # Create a blog pod
-pod create my-blog
+podctl pod create my-blog
+
+# Create public posts stream
+podctl stream create my-blog posts --access public
 
 # Write blog posts
-pod write my-blog posts/welcome '{"title": "Welcome!", "content": "Hello world"}'
-pod write my-blog posts/second '{"title": "Second Post", "content": "More content"}'
-
-# Make posts public
-pod permissions my-blog posts set --mode public
+podctl record write my-blog posts welcome '{"title": "Welcome!", "content": "Hello world"}'
+podctl record write my-blog posts second '{"title": "Second Post", "content": "More content"}'
 
 # List all posts
-pod record list my-blog posts
+podctl record list my-blog posts
 ```
 
 ### Collaborative Notes
 
 ```bash
 # Create shared pod
-pod create team-notes
+podctl pod create team-notes
 
-# Create permission stream
-pod write team-notes permissions/editors '{"userId": "user123", "read": true, "write": true}'
+# Create permission stream and add editors
+podctl stream create team-notes permissions/editors --access private
+podctl record write team-notes permissions/editors user123 '{"userId": "user123", "read": true, "write": true}'
 
-# Set stream to use permissions
-pod permissions team-notes notes set --mode /permissions/editors
+# Create notes stream controlled by permissions
+podctl stream create team-notes notes --access /permissions/editors
 
 # Write notes
-pod write team-notes notes/meeting "Meeting notes..."
+podctl record write team-notes notes meeting "Meeting notes..."
 ```
 
 ### Data Backup
 
 ```bash
 # Export all records from a stream
-pod record list my-pod important-data --format json > backup.json
+podctl record list my-pod important-data --format json > backup.json
 
 # Read specific record to file
-pod read my-pod config settings --output settings.json
+podctl record read my-pod config settings --output settings.json
+
+# Verify stream integrity before backup
+podctl record verify my-pod important-data --check-integrity
 ```
 
 ## Environment Variables
@@ -316,18 +380,18 @@ pod read my-pod config settings --output settings.json
 
 ### Authentication Issues
 
-- Ensure your token is valid: `pod whoami`
-- Try re-authenticating: `pod logout` then `pod login`
+- Ensure your token is valid: `podctl auth info`
+- Try re-authenticating: `podctl logout` then `podctl login`
 
 ### Network Issues
 
-- Check server URL: `pod config`
-- Test connection: `pod whoami --server <url>`
+- Check server URL: `podctl config`
+- Test connection: `podctl auth info --server <url>`
 
 ### Permission Denied
 
-- Verify you own the pod: `pod info <pod>`
-- Check stream permissions: `pod permissions <pod> <stream> view`
+- Verify you own the pod: `podctl pod info <pod>`
+- Check stream permissions: `podctl permission list <pod> <stream>`
 
 ## Development
 

--- a/node/packages/webpods-cli/package-lock.json
+++ b/node/packages/webpods-cli/package-lock.json
@@ -14,7 +14,7 @@
         "yargs": "^17.7.2"
       },
       "bin": {
-        "pod": "dist/index.js"
+        "podctl": "dist/index.js"
       },
       "devDependencies": {
         "typescript": "^5.7.3"

--- a/node/packages/webpods-cli/package.json
+++ b/node/packages/webpods-cli/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "eslint src --ext .ts --fix"
   },
   "bin": {
-    "pod": "dist/index.js"
+    "podctl": "dist/index.js"
   },
   "type": "module",
   "repository": {

--- a/node/packages/webpods-cli/src/commands/records/records.ts
+++ b/node/packages/webpods-cli/src/commands/records/records.ts
@@ -1,5 +1,5 @@
 /**
- * Record operations (read, write, list)
+ * Record operations (read, write, list, delete)
  */
 
 import { promises as fs } from "fs";
@@ -449,6 +449,114 @@ export async function list(options: {
     logger.error("List command failed", {
       pod: options.pod,
       stream: options.stream,
+      error: errorMessage,
+    });
+    output.error("Error: " + errorMessage);
+    process.exit(1);
+  }
+}
+
+/**
+ * Delete (soft delete) a record by writing a tombstone
+ */
+export async function deleteRecord(options: {
+  quiet?: boolean;
+  pod?: string;
+  stream?: string;
+  name?: string;
+  hard?: boolean;
+  token?: string;
+  server?: string;
+  profile?: string;
+  [key: string]: unknown;
+}): Promise<void> {
+  const output = createCliOutput(options.quiet);
+
+  try {
+    logger.debug("Deleting record", {
+      pod: options.pod,
+      stream: options.stream,
+      name: options.name,
+      hard: options.hard,
+    });
+
+    if (!options.pod || !options.stream || !options.name) {
+      output.error("Pod, stream, and name are required for deleting records.");
+      process.exit(1);
+    }
+
+    if (options.hard) {
+      // Hard delete (purge) - use DELETE method
+      const path = `/${options.stream}/${options.name}`;
+      const result = await podRequest(options.pod, path, {
+        method: "DELETE",
+        token: options.token,
+        server: options.server,
+        profile: options.profile,
+      });
+
+      logger.debug("Delete response", {
+        success: result.success,
+        error: result.success ? null : result.error,
+      });
+
+      if (result.success) {
+        output.success(
+          `Record '${options.name}' permanently deleted from ${options.pod}/${options.stream}`,
+        );
+      } else {
+        const errorMessage =
+          result.error.message ||
+          result.error.code ||
+          "Failed to delete record";
+        throw new Error(errorMessage);
+      }
+    } else {
+      // Soft delete - write tombstone record
+      const tombstoneContent = JSON.stringify({ deleted: true });
+      const path = `/${options.stream}/${options.name}`;
+
+      const result = await podRequest(options.pod, path, {
+        method: "POST",
+        body: tombstoneContent,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        token: options.token,
+        server: options.server,
+        profile: options.profile,
+      });
+
+      logger.debug("Delete (tombstone) response", {
+        success: result.success,
+        error: result.success ? null : result.error,
+      });
+
+      if (result.success) {
+        output.success(
+          `Record '${options.name}' marked as deleted in ${options.pod}/${options.stream}`,
+        );
+      } else {
+        const errorMessage =
+          result.error.message ||
+          result.error.code ||
+          "Failed to delete record";
+        throw new Error(errorMessage);
+      }
+    }
+
+    logger.info("Record deleted successfully", {
+      pod: options.pod,
+      stream: options.stream,
+      name: options.name,
+      hard: options.hard,
+    });
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error("Delete command failed", {
+      pod: options.pod,
+      stream: options.stream,
+      name: options.name,
       error: errorMessage,
     });
     output.error("Error: " + errorMessage);

--- a/node/packages/webpods-cli/src/commands/schema/schema.ts
+++ b/node/packages/webpods-cli/src/commands/schema/schema.ts
@@ -13,18 +13,9 @@ export async function schemaEnable(argv: Arguments) {
     const config = await getConfigWithAuth(argv);
     const client = getClient(config);
 
-    const streamPath = argv.stream as string;
+    const pod = argv.pod as string;
+    const stream = argv.stream as string;
     const schemaFile = argv.file as string;
-
-    // Parse pod and stream from the path
-    const parts = streamPath.split("/");
-    const pod = parts[0];
-    const stream = parts.slice(1).join("/");
-
-    if (!pod || !stream) {
-      output.error("Invalid stream path. Format: <pod>/<stream>");
-      process.exit(1);
-    }
 
     // Read and validate schema file
     let schemaContent: any;
@@ -60,7 +51,7 @@ export async function schemaEnable(argv: Arguments) {
     });
 
     if (response.ok) {
-      output.success(`Schema enabled for ${streamPath}`);
+      output.success(`Schema enabled for ${pod}/${stream}`);
       if (argv.verbose) {
         output.info(`Schema written to: ${pod}${schemaPath}`);
       }
@@ -90,17 +81,8 @@ export async function schemaDisable(argv: Arguments) {
     const config = await getConfigWithAuth(argv);
     const client = getClient(config);
 
-    const streamPath = argv.stream as string;
-
-    // Parse pod and stream from the path
-    const parts = streamPath.split("/");
-    const pod = parts[0];
-    const stream = parts.slice(1).join("/");
-
-    if (!pod || !stream) {
-      output.error("Invalid stream path. Format: <pod>/<stream>");
-      process.exit(1);
-    }
+    const pod = argv.pod as string;
+    const stream = argv.stream as string;
 
     // Prepare disabled schema definition
     const schemaDef = {
@@ -117,7 +99,7 @@ export async function schemaDisable(argv: Arguments) {
     });
 
     if (response.ok) {
-      output.success(`Schema disabled for ${streamPath}`);
+      output.success(`Schema disabled for ${pod}/${stream}`);
     } else {
       const errorText = await response.text();
       try {

--- a/node/packages/webpods-cli/src/commands/utils/utils.ts
+++ b/node/packages/webpods-cli/src/commands/utils/utils.ts
@@ -20,21 +20,36 @@ export async function config(options: {
     logger.debug("Displaying configuration");
 
     const currentConfig = await loadConfig();
+    const currentProfile = currentConfig.currentProfile;
+    const profile =
+      currentProfile && currentConfig.profiles
+        ? currentConfig.profiles[currentProfile]
+        : null;
 
     output.print("WebPods CLI Configuration:");
     output.print("─".repeat(30));
-    output.print(`Server:        ${currentConfig.server}`);
-    output.print(`Output Format: ${currentConfig.outputFormat}`);
-    output.print(`Token:         ${currentConfig.token ? "Set" : "Not set"}`);
-    output.print(`Default Pod:   ${currentConfig.defaultPod || "Not set"}`);
+
+    if (profile) {
+      output.print(`Current Profile: ${currentProfile}`);
+      output.print(`Server:          ${profile.server}`);
+      output.print(`Token:           ${profile.token ? "Set" : "Not set"}`);
+      output.print(
+        `Output Format:   ${profile.outputFormat || currentConfig.outputFormat || "table"}`,
+      );
+      output.print(`Default Pod:     ${profile.defaultPod || "Not set"}`);
+    } else {
+      output.print("No profile configured.");
+      output.print(
+        "Run 'podctl profile add <name> --server <url>' to get started.",
+      );
+    }
 
     output.print("\nConfiguration file: ~/.webpods/config.json");
+    output.print("To manage profiles: podctl profile list");
 
     logger.info("Configuration displayed", {
-      server: currentConfig.server,
-      outputFormat: currentConfig.outputFormat,
-      hasToken: !!currentConfig.token,
-      defaultPod: currentConfig.defaultPod,
+      currentProfile,
+      hasProfile: !!profile,
     });
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -61,7 +76,7 @@ export async function configSet(options: {
       value: options.value,
     });
 
-    const validKeys = ["server", "outputFormat", "defaultPod"] as const;
+    const validKeys = ["outputFormat", "defaultPod"] as const;
     type ValidKey = (typeof validKeys)[number];
 
     if (
@@ -88,49 +103,6 @@ export async function configSet(options: {
     logger.error("Config set command failed", {
       key: options.key,
       value: options.value,
-      error: errorMessage,
-    });
-    output.error("Error: " + errorMessage);
-    process.exit(1);
-  }
-}
-
-/**
- * Set WebPods server URL
- */
-export async function configServer(options: {
-  quiet?: boolean;
-  url?: string;
-  [key: string]: unknown;
-}): Promise<void> {
-  const output = createCliOutput(options.quiet);
-
-  try {
-    logger.debug("Setting server URL", { url: options.url });
-
-    // Basic URL validation
-    if (!options.url) {
-      output.error("URL is required");
-      logger.error("No URL provided for server config");
-      process.exit(1);
-    }
-    try {
-      new URL(options.url);
-    } catch {
-      output.error("Invalid URL provided");
-      logger.error("Invalid URL provided for server config", {
-        url: options.url,
-      });
-      process.exit(1);
-    }
-
-    await updateConfig("server", options.url);
-    output.success(`Server URL updated: ${options.url}`);
-    logger.info("Server URL updated", { url: options.url });
-  } catch (error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.error("Config server command failed", {
-      url: options.url,
       error: errorMessage,
     });
     output.error("Error: " + errorMessage);

--- a/node/packages/webpods-cli/src/index.ts
+++ b/node/packages/webpods-cli/src/index.ts
@@ -18,7 +18,7 @@ import {
   deletePod,
   infoPod,
 } from "./commands/pods/index.js";
-import { write, read, list } from "./commands/records/index.js";
+import { write, read, list, deleteRecord } from "./commands/records/index.js";
 import {
   streams,
   deleteStream,
@@ -31,7 +31,7 @@ import {
   oauthDelete,
   oauthInfo,
 } from "./commands/oauth/index.js";
-import { config, configSet, configServer } from "./commands/utils/index.js";
+import { config, configSet } from "./commands/utils/index.js";
 import {
   profileList,
   profileAdd,
@@ -67,44 +67,52 @@ const logger = createLogger("webpods:cli");
 
 export async function main() {
   await yargs(hideBin(process.argv))
-    // Authentication Commands
+    // Authentication Management
     .command(
-      "login",
-      "Show available OAuth providers for authentication",
-      {},
-      async (argv) => {
-        await login(argv);
-      },
-    )
-    .command(
-      "logout",
-      "Clear stored authentication token",
-      {},
-      async (argv) => {
-        await logout(argv);
-      },
-    )
-    .command(
-      "whoami",
-      "Show current authenticated user information",
+      "auth",
+      "Manage authentication",
       (yargs) =>
         yargs
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await whoami(argv);
-      },
+          .command(
+            "login",
+            "Show available OAuth providers for authentication",
+            {},
+            async (argv) => {
+              await login(argv);
+            },
+          )
+          .command(
+            "logout",
+            "Clear stored authentication token",
+            {},
+            async (argv) => {
+              await logout(argv);
+            },
+          )
+          .command(
+            "info",
+            "Show current authenticated user information",
+            (yargs) =>
+              yargs
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table", "csv"] as const,
+                  describe: "Output format",
+                }),
+            async (argv) => {
+              await whoami(argv);
+            },
+          )
+          .demandCommand(1, "Please specify an auth command"),
+      () => {},
     )
     // Token subcommands
     .command(
@@ -206,128 +214,142 @@ export async function main() {
       () => {},
     )
 
-    // Pod Management - List command (replaces 'pods')
-    .command(
-      "list",
-      "List all your pods",
-      (yargs) =>
-        yargs
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await listPods(argv);
-      },
-    )
-
     // Pod Management
     .command(
-      "create <name>",
-      "Create a new pod",
+      "pod",
+      "Manage pods",
       (yargs) =>
         yargs
-          .positional("name", {
-            describe: "Pod name (subdomain)",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await createPod(argv);
-      },
-    )
-    // Keep 'pods' as alias for backward compatibility
-    .command(
-      "pods",
-      "List all your pods (alias for 'list')",
-      (yargs) =>
-        yargs
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await listPods(argv);
-      },
-    )
-    .command(
-      "delete <pod>",
-      "Delete a pod and all its data",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name to delete",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("force", {
-            type: "boolean",
-            describe: "Skip confirmation prompt",
-          }),
-      async (argv) => {
-        await deletePod(argv);
-      },
-    )
-    .command(
-      "info <pod>",
-      "Show pod details and statistics",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await infoPod(argv);
-      },
+          .command(
+            "create <name>",
+            "Create a new pod",
+            (yargs) =>
+              yargs
+                .positional("name", {
+                  describe: "Pod name (subdomain)",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await createPod(argv);
+            },
+          )
+          .command(
+            "list",
+            "List all your pods",
+            (yargs) =>
+              yargs
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table", "csv"] as const,
+                  describe: "Output format",
+                }),
+            async (argv) => {
+              await listPods(argv);
+            },
+          )
+          .command(
+            "delete <pod>",
+            "Delete a pod and all its data",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod to delete",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("force", {
+                  type: "boolean",
+                  describe: "Skip confirmation prompt",
+                }),
+            async (argv) => {
+              await deletePod(argv);
+            },
+          )
+          .command(
+            "info <pod>",
+            "Show pod details and statistics",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table"] as const,
+                  describe: "Output format",
+                }),
+            async (argv) => {
+              await infoPod(argv);
+            },
+          )
+          .command(
+            "transfer <pod> <user>",
+            "Transfer pod ownership",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod to transfer",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("user", {
+                  describe: "New owner user ID",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("force", {
+                  type: "boolean",
+                  describe: "Skip confirmation prompt",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await transfer(argv);
+            },
+          )
+          .demandCommand(1, "Please specify a pod command"),
+      () => {},
     )
 
     // Record Management
@@ -385,125 +407,166 @@ export async function main() {
               await list(argv);
             },
           )
+          .command(
+            "write <pod> <stream> <name> [data]",
+            "Write data to a stream record",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Stream path",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("name", {
+                  describe: "Record name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("data", {
+                  describe: "Data to write",
+                  type: "string",
+                })
+                .option("file", {
+                  alias: "f",
+                  type: "string",
+                  describe: "Read data from file",
+                })
+                .option("permission", {
+                  type: "string",
+                  describe: "Set access permission (public, private, /stream)",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await write(argv);
+            },
+          )
+          .command(
+            "read <pod> <stream> [name]",
+            "Read data from a stream record",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Stream path",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("name", {
+                  describe: "Record name",
+                  type: "string",
+                })
+                .option("index", {
+                  alias: "i",
+                  type: "string",
+                  describe: "Read by index (-1 for latest, 0:10 for range)",
+                })
+                .option("output", {
+                  alias: "o",
+                  type: "string",
+                  describe: "Save to file",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await read(argv);
+            },
+          )
+          .command(
+            "delete <pod> <stream> <name>",
+            "Delete a record (soft delete by default)",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Stream path",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("name", {
+                  describe: "Record name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("hard", {
+                  type: "boolean",
+                  describe: "Permanently delete (purge) the record",
+                  default: false,
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await deleteRecord(argv);
+            },
+          )
+          .command(
+            "verify <pod> <stream>",
+            "Verify hash chain integrity",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Stream to verify",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("show-chain", {
+                  type: "boolean",
+                  describe: "Display full hash chain",
+                })
+                .option("check-integrity", {
+                  type: "boolean",
+                  describe: "Verify hash chain integrity",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await verify(argv);
+            },
+          )
           .demandCommand(1, "Please specify a record command"),
       () => {},
-    )
-
-    // Write & Read Operations (top-level for convenience)
-    .command(
-      "write <pod> <stream> <name> [data]",
-      "Write data to a stream record (stream must exist)",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("stream", {
-            describe: "Stream path (must be created first)",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("name", {
-            describe: "Record name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("data", {
-            describe: "Data to write",
-            type: "string",
-          })
-          .option("file", {
-            alias: "f",
-            type: "string",
-            describe: "Read data from file",
-          })
-          .option("permission", {
-            type: "string",
-            describe: "Set access permission (public, private, /stream)",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await write(argv);
-      },
-    )
-    .command(
-      "read <pod> <stream> [name]",
-      "Read data from a stream record",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("stream", {
-            describe: "Stream path",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("name", {
-            describe: "Record name",
-            type: "string",
-          })
-          .option("index", {
-            alias: "i",
-            type: "string",
-            describe: "Read by index (-1 for latest, 0:10 for range)",
-          })
-          .option("output", {
-            alias: "o",
-            type: "string",
-            describe: "Save to file",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await read(argv);
-      },
-    )
-
-    // Convenience alias for listing streams
-    .command(
-      "streams <pod>",
-      "List all streams in a pod",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await streams(argv);
-      },
     )
 
     // Stream Management
@@ -609,129 +672,125 @@ export async function main() {
 
     // Permission Management
     .command(
-      "permissions <pod> <stream> [action]",
-      "Manage stream permissions",
+      "permission",
+      "Manage permissions",
       (yargs) =>
         yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("stream", {
-            describe: "Stream path",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("action", {
-            describe: "Action: view, set, grant, revoke, list",
-            type: "string",
-            choices: ["view", "set", "grant", "revoke", "list"],
-            default: "view",
-          })
-          .option("mode", {
-            type: "string",
-            describe: "Permission mode (public, private, /stream)",
-          })
-          .option("user", {
-            type: "string",
-            describe: "User ID for grant/revoke actions",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await permissions(argv);
-      },
+          .command(
+            "list <pod> <stream>",
+            "List permissions for a stream",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Permission stream path",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("user", {
+                  type: "string",
+                  describe: "Filter by user ID",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table", "csv"] as const,
+                  describe: "Output format",
+                }),
+            async (argv) => {
+              await permissions(argv);
+            },
+          )
+          .command(
+            "grant <pod> <stream> <user>",
+            "Grant permissions to a user",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Permission stream path",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("user", {
+                  describe: "User ID to grant permissions to",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("read", {
+                  type: "boolean",
+                  describe: "Grant read permission",
+                })
+                .option("write", {
+                  type: "boolean",
+                  describe: "Grant write permission",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await grant(argv);
+            },
+          )
+          .command(
+            "revoke <pod> <stream> <user>",
+            "Revoke permissions from a user",
+            (yargs) =>
+              yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("stream", {
+                  describe: "Permission stream path",
+                  demandOption: true,
+                  type: "string",
+                })
+                .positional("user", {
+                  describe: "User ID to revoke permissions from",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await revoke(argv);
+            },
+          )
+          .demandCommand(1, "Please specify a permission command"),
+      () => {},
     )
 
-    // Grant and Revoke Commands
+    // Link Management
     .command(
-      "grant <pod> <stream> <user>",
-      "Grant permissions to a user",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("stream", {
-            describe: "Permission stream path",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("user", {
-            describe: "User ID to grant permissions to",
-            demandOption: true,
-            type: "string",
-          })
-          .option("read", {
-            type: "boolean",
-            describe: "Grant read permission",
-          })
-          .option("write", {
-            type: "boolean",
-            describe: "Grant write permission",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await grant(argv);
-      },
-    )
-    .command(
-      "revoke <pod> <stream> <user>",
-      "Revoke permissions from a user",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("stream", {
-            describe: "Permission stream path",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("user", {
-            describe: "User ID to revoke permissions from",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await revoke(argv);
-      },
-    )
-
-    // Links Management
-    .command(
-      "links",
+      "link",
       "Manage pod links and routing",
       (yargs) =>
         yargs
@@ -821,7 +880,7 @@ export async function main() {
               await linksRemove(argv);
             },
           )
-          .demandCommand(1, "Please specify a links command"),
+          .demandCommand(1, "Please specify a link command"),
       () => {},
     )
 
@@ -916,43 +975,6 @@ export async function main() {
       () => {},
     )
 
-    // Verification Command
-    .command(
-      "verify <pod> <stream>",
-      "Verify hash chain integrity",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("stream", {
-            describe: "Stream to verify",
-            demandOption: true,
-            type: "string",
-          })
-          .option("show-chain", {
-            type: "boolean",
-            describe: "Display full hash chain",
-          })
-          .option("check-integrity", {
-            type: "boolean",
-            describe: "Verify hash chain integrity",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await verify(argv);
-      },
-    )
-
     // Schema Management
     .command(
       "schema",
@@ -960,12 +982,17 @@ export async function main() {
       (yargs) =>
         yargs
           .command(
-            "enable <stream> <file>",
+            "enable <pod> <stream> <file>",
             "Enable schema validation for a stream",
             (yargs) =>
               yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
                 .positional("stream", {
-                  describe: "Stream path (pod/stream)",
+                  describe: "Stream path",
                   demandOption: true,
                   type: "string",
                 })
@@ -1003,12 +1030,17 @@ export async function main() {
             },
           )
           .command(
-            "disable <stream>",
+            "disable <pod> <stream>",
             "Disable schema validation for a stream",
             (yargs) =>
               yargs
+                .positional("pod", {
+                  describe: "Pod name",
+                  demandOption: true,
+                  type: "string",
+                })
                 .positional("stream", {
-                  describe: "Stream path (pod/stream)",
+                  describe: "Stream path",
                   demandOption: true,
                   type: "string",
                 })
@@ -1028,173 +1060,157 @@ export async function main() {
       () => {},
     )
 
-    // Transfer Ownership
-    .command(
-      "transfer <pod> <user>",
-      "Transfer pod ownership",
-      (yargs) =>
-        yargs
-          .positional("pod", {
-            describe: "Pod name",
-            demandOption: true,
-            type: "string",
-          })
-          .positional("user", {
-            describe: "New owner user ID",
-            demandOption: true,
-            type: "string",
-          })
-          .option("force", {
-            type: "boolean",
-            describe: "Skip confirmation prompt",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await transfer(argv);
-      },
-    )
-
     // Rate Limits
+    // Rate Limit Management
     .command(
-      "limits",
-      "Check rate limit status",
+      "limit",
+      "Manage rate limits",
       (yargs) =>
         yargs
-          .option("action", {
-            type: "string",
-            describe: "Specific action to check (read, write, etc.)",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await limits(argv);
-      },
+          .command(
+            "info",
+            "Check rate limit status",
+            (yargs) =>
+              yargs
+                .option("action", {
+                  type: "string",
+                  describe: "Specific action to check (read, write, etc.)",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table", "csv"] as const,
+                  describe: "Output format",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await limits(argv);
+            },
+          )
+          .demandCommand(1, "Please specify a limit command"),
+      () => {},
     )
 
     // OAuth Client Management
     .command(
-      "oauth register",
-      "Register a new OAuth client",
+      "oauth",
+      "Manage OAuth clients",
       (yargs) =>
         yargs
-          .option("name", {
-            type: "string",
-            demandOption: true,
-            describe: "Application name",
-          })
-          .option("redirect", {
-            type: "string",
-            demandOption: true,
-            describe: "Redirect URI",
-          })
-          .option("pods", {
-            type: "string",
-            describe: "Comma-separated list of pods to request access to",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          }),
-      async (argv) => {
-        await oauthRegister(argv);
-      },
-    )
-    .command(
-      "oauth list",
-      "List your OAuth clients",
-      (yargs) =>
-        yargs
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await oauthList(argv);
-      },
-    )
-    .command(
-      "oauth delete <clientId>",
-      "Delete an OAuth client",
-      (yargs) =>
-        yargs
-          .positional("clientId", {
-            describe: "Client ID to delete",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("force", {
-            type: "boolean",
-            describe: "Skip confirmation prompt",
-          }),
-      async (argv) => {
-        await oauthDelete(argv);
-      },
-    )
-    .command(
-      "oauth info <clientId>",
-      "Show OAuth client details",
-      (yargs) =>
-        yargs
-          .positional("clientId", {
-            describe: "Client ID",
-            demandOption: true,
-            type: "string",
-          })
-          .option("token", {
-            type: "string",
-            describe: "Use specific token for this command",
-          })
-          .option("server", {
-            type: "string",
-            describe: "WebPods server URL",
-          })
-          .option("format", {
-            type: "string",
-            choices: ["json", "yaml", "table", "csv"] as const,
-            describe: "Output format",
-          }),
-      async (argv) => {
-        await oauthInfo(argv);
-      },
+          .command(
+            "register",
+            "Register a new OAuth client",
+            (yargs) =>
+              yargs
+                .option("name", {
+                  type: "string",
+                  demandOption: true,
+                  describe: "Application name",
+                })
+                .option("redirect", {
+                  type: "string",
+                  demandOption: true,
+                  describe: "Redirect URI",
+                })
+                .option("pods", {
+                  type: "string",
+                  describe: "Comma-separated list of pods to request access to",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                }),
+            async (argv) => {
+              await oauthRegister(argv);
+            },
+          )
+          .command(
+            "list",
+            "List your OAuth clients",
+            (yargs) =>
+              yargs
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table", "csv"] as const,
+                  describe: "Output format",
+                }),
+            async (argv) => {
+              await oauthList(argv);
+            },
+          )
+          .command(
+            "delete <clientId>",
+            "Delete an OAuth client",
+            (yargs) =>
+              yargs
+                .positional("clientId", {
+                  describe: "Client ID to delete",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("force", {
+                  type: "boolean",
+                  describe: "Skip confirmation prompt",
+                }),
+            async (argv) => {
+              await oauthDelete(argv);
+            },
+          )
+          .command(
+            "info <clientId>",
+            "Show OAuth client details",
+            (yargs) =>
+              yargs
+                .positional("clientId", {
+                  describe: "Client ID",
+                  demandOption: true,
+                  type: "string",
+                })
+                .option("token", {
+                  type: "string",
+                  describe: "Use specific token for this command",
+                })
+                .option("server", {
+                  type: "string",
+                  describe: "WebPods server URL",
+                })
+                .option("format", {
+                  type: "string",
+                  choices: ["json", "yaml", "table", "csv"] as const,
+                  describe: "Output format",
+                }),
+            async (argv) => {
+              await oauthInfo(argv);
+            },
+          )
+          .demandCommand(1, "Please specify an oauth command"),
+      () => {},
     )
 
     // Utility Commands
@@ -1219,17 +1235,22 @@ export async function main() {
         }
       },
     )
+
+    // Top-level aliases for common commands
     .command(
-      "config server <url>",
-      "Set WebPods server URL",
-      (yargs) =>
-        yargs.positional("url", {
-          describe: "Server URL",
-          demandOption: true,
-          type: "string",
-        }),
+      "login",
+      "Authenticate with WebPods (alias for auth login)",
+      {},
       async (argv) => {
-        await configServer(argv);
+        await login(argv);
+      },
+    )
+    .command(
+      "logout",
+      "Clear authentication (alias for auth logout)",
+      {},
+      async (argv) => {
+        await logout(argv);
       },
     )
 

--- a/node/packages/webpods/package-lock.json
+++ b/node/packages/webpods/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpods",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpods",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "license": "MIT",
       "dependencies": {
         "@ory/hydra-client": "^2.4.0-alpha.1",


### PR DESCRIPTION
- Changed binary name from 'pod' to 'podctl' for clearer distinction
- Refactored all commands to follow <resource> <action> pattern:
  - auth: login, logout, info (renamed from whoami)
  - pod: create, delete, list, info, transfer
  - record: write, read, list, delete (new)
  - stream: list, create, delete
  - permission: grant, revoke, list
  - schema: enable, disable
  - link: create, list
  - domain: create
  - oauth: callback
  - profile: add, list, use, delete, current
- Added convenient top-level aliases for login/logout
- Fixed parameter inconsistencies (all pod commands now use <pod>)
- Removed deprecated configServer function and config server command
- Updated all tests to match new command structure (116 tests passing)
- Updated documentation to reflect new podctl commands

🤖 Generated with [Claude Code](https://claude.ai/code)