### PR TITLE
fix: Remove cookie support from JWT token authentication

### DIFF
--- a/node/packages/webpods/src/auth/routes.ts
+++ b/node/packages/webpods/src/auth/routes.ts
@@ -255,9 +255,7 @@ router.get("/success", (req: Request, res: Response) => {
  * GET /auth/whoami
  */
 router.get("/whoami", async (req: Request, res: Response) => {
-  const token =
-    (req as RequestWithSession).cookies?.token ||
-    req.headers.authorization?.replace("Bearer ", "");
+  const token = req.headers.authorization?.replace("Bearer ", "");
 
   if (!token) {
     res.status(401).json({

--- a/node/packages/webpods/src/middleware/hybrid-auth.ts
+++ b/node/packages/webpods/src/middleware/hybrid-auth.ts
@@ -14,28 +14,18 @@ const logger = createLogger("webpods:auth:hybrid");
 /**
  * Extract token from request
  */
-function extractToken(req: Request, currentPod?: string): string | null {
-  // For pod requests, prefer pod_token cookie
-  let token = currentPod
-    ? (req as { cookies?: Record<string, string> }).cookies?.pod_token
-    : (req as { cookies?: Record<string, string> }).cookies?.token;
-
-  if (!token) {
-    token = (req as { cookies?: Record<string, string> }).cookies?.token; // Fallback to regular token
-  }
-
-  if (!token) {
-    const authHeader = req.headers.authorization;
-    if (authHeader) {
-      if (authHeader.startsWith("Bearer ")) {
-        token = authHeader.substring(7);
-      } else if (!authHeader.includes(" ")) {
-        token = authHeader;
-      }
+function extractToken(req: Request): string | null {
+  // Only extract token from Authorization header
+  const authHeader = req.headers.authorization;
+  if (authHeader) {
+    if (authHeader.startsWith("Bearer ")) {
+      return authHeader.substring(7);
+    } else if (!authHeader.includes(" ")) {
+      return authHeader;
     }
   }
 
-  return token || null;
+  return null;
 }
 
 /**
@@ -53,7 +43,7 @@ export async function authenticateHybrid(
 
   try {
     const currentPod = req.podName || undefined;
-    const token = extractToken(req, currentPod);
+    const token = extractToken(req);
 
     if (!token) {
       if (!res.headersSent) {


### PR DESCRIPTION
- Remove JWT token extraction from cookies in hybrid-auth middleware
- Only accept tokens via Authorization header for API authentication
- Remove cookie token extraction from /auth/whoami endpoint
- Improves security by preventing CSRF attacks on API endpoints
- Session cookies for OAuth flow remain unchanged

BREAKING CHANGE: API clients must use Authorization header instead of cookies

🤖 Generated with [Claude Code](https://claude.ai/code)