### PR TITLE
docs: Remove promotional language and add missing CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 **Build append-only applications with cryptographic verification using just HTTP and subdomains.**
 
-WebPods turns subdomains into personal data stores with immutable, hash-chained records. Perfect for audit logs, event streams, content versioning, and any application requiring tamper-proof data.
+WebPods turns subdomains into personal data stores with immutable, hash-chained records. Suitable for audit logs, event streams, content versioning, and applications requiring tamper-proof data.
 
-## What You Can Build
+## Use Cases
 
-- 🔍 **Audit Trails** - Immutable logs with cryptographic proof of integrity
-- 📝 **Blogging Platforms** - Content with built-in version history and authorship
-- 📊 **IoT Data Collection** - Append-only sensor data streams with timestamps
-- 🔐 **Secure Backups** - Tamper-evident data storage with hash verification
-- 🤝 **Collaborative Apps** - Multi-user data with clear ownership and permissions
-- 📈 **Event Sourcing** - Natural fit for event-driven architectures
-- 🏦 **Financial Records** - Immutable transaction logs with cryptographic proofs
-- 📜 **Document Versioning** - Track every change with hash-chained history
+- **Audit Trails** - Immutable logs with cryptographic proof of integrity
+- **Blogging Platforms** - Content with built-in version history and authorship
+- **IoT Data Collection** - Append-only sensor data streams with timestamps
+- **Secure Backups** - Tamper-evident data storage with hash verification
+- **Collaborative Apps** - Multi-user data with clear ownership and permissions
+- **Event Sourcing** - Natural fit for event-driven architectures
+- **Financial Records** - Immutable transaction logs with cryptographic proofs
+- **Document Versioning** - Track every change with hash-chained history
 
 ## Quick Example
 
@@ -43,7 +43,7 @@ curl https://alice.webpods.org/blog/posts/1
 }
 ```
 
-That's it! You now have a cryptographically-verified, append-only data store at `alice.webpods.org`.
+You now have a cryptographically-verified, append-only data store at `alice.webpods.org`.
 
 ## Core Concepts
 
@@ -353,6 +353,20 @@ podctl permission grant POD PATH USER
 podctl permission revoke POD PATH USER
 podctl permission list POD PATH
 
+# Links (aliases/redirects)
+podctl link set POD SOURCE TARGET
+podctl link list POD
+podctl link remove POD SOURCE
+
+# OAuth clients
+podctl oauth register NAME --redirect-uri URL
+podctl oauth list
+podctl oauth info CLIENT_ID
+podctl oauth delete CLIENT_ID
+
+# Rate limits
+podctl limit info
+
 # Profiles (multiple servers)
 podctl profile add NAME --server URL
 podctl profile use NAME
@@ -544,35 +558,35 @@ See [examples documentation](docs/examples.md) for more use cases including cont
 
 ## Key Features
 
-### 🔐 Cryptographic Integrity
+### Cryptographic Integrity
 
 Every record contains a SHA-256 hash of the previous record, creating an immutable chain. Tampering with any historical record breaks the chain and is immediately detectable.
 
-### 🌐 HTTP-Native API
+### HTTP-Native API
 
 No special protocols, libraries, or clients required. Everything works over standard HTTP/HTTPS. Each pod gets its own subdomain for data isolation.
 
-### 📝 Append-Only Guarantees
+### Append-Only Guarantees
 
-Records can never be modified after creation. Deletions only mark records as deleted without removing them. Perfect for audit trails, compliance, and event sourcing.
+Records can never be modified after creation. Deletions only mark records as deleted without removing them. Designed for audit trails, compliance, and event sourcing.
 
-### 🔑 Flexible Permissions
+### Flexible Permissions
 
 Fine-grained access control per stream. Public streams allow anonymous reads. Private streams require authentication. Custom permissions grant specific users access.
 
-### 🚀 Simple Scaling
+### Simple Scaling
 
 Pods are independent namespaces. Scale horizontally by adding servers. Use DNS to route pods to different servers. No complex sharding required.
 
-### 🔌 OAuth 2.0 for Apps
+### OAuth 2.0 for Apps
 
 Full OAuth 2.0 and OpenID Connect support through Ory Hydra. Third-party developers can build applications that interact with user pods after obtaining consent.
 
-### 📦 Multiple Data Formats
+### Multiple Data Formats
 
 Store JSON, plain text, or binary data. Content-Type headers are preserved. Large content can be streamed.
 
-### ⚡ Efficient Queries
+### Efficient Queries
 
 Pagination with positive/negative offsets. Unique record filtering for configuration use cases. Field selection to reduce bandwidth. Range queries for time-series data.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -678,6 +678,181 @@ podctl config list
 # format: json
 ```
 
+## Link Commands
+
+### `podctl link set`
+
+Create a link/redirect from one stream to another.
+
+```bash
+podctl link set my-pod /old/path /new/path
+
+# Output: Link created from /old/path to /new/path
+```
+
+**Arguments:**
+
+- `POD` - Pod name
+- `SOURCE` - Source stream path
+- `TARGET` - Target stream path
+
+### `podctl link list`
+
+List all links in a pod.
+
+```bash
+podctl link list my-pod
+
+# Output:
+# SOURCE         TARGET           CREATED
+# /old/api       /v2/api          2024-01-15T10:30:00Z
+# /legacy        /current         2024-01-14T09:20:00Z
+```
+
+**Arguments:**
+
+- `POD` - Pod name
+
+**Options:**
+
+- `--json` - Output as JSON
+
+### `podctl link remove`
+
+Remove a link.
+
+```bash
+podctl link remove my-pod /old/path
+
+# Output: Link removed
+```
+
+**Arguments:**
+
+- `POD` - Pod name
+- `SOURCE` - Source stream path
+
+**Options:**
+
+- `--force` - Skip confirmation
+
+## OAuth Client Commands
+
+### `podctl oauth register`
+
+Register a new OAuth client application.
+
+```bash
+podctl oauth register "My Application" \
+  --redirect-uri https://myapp.com/callback \
+  --scope "openid offline pod:read pod:write"
+
+# Output:
+# OAuth client registered successfully
+# Client ID: abc123xyz
+# Client Secret: secret789xyz
+# Save these credentials securely!
+```
+
+**Arguments:**
+
+- `NAME` - Application name
+
+**Options:**
+
+- `--redirect-uri URI` - Redirect URI (can be specified multiple times)
+- `--scope SCOPE` - OAuth scopes
+- `--grant-type TYPE` - Grant types (default: authorization_code,refresh_token)
+- `--logo-uri URI` - Application logo URL
+- `--client-uri URI` - Application homepage URL
+- `--policy-uri URI` - Privacy policy URL
+- `--tos-uri URI` - Terms of service URL
+
+### `podctl oauth list`
+
+List your registered OAuth clients.
+
+```bash
+podctl oauth list
+
+# Output:
+# CLIENT_ID    NAME                CREATED
+# abc123xyz    My Application      2024-01-15T10:30:00Z
+# def456abc    Test App            2024-01-14T09:20:00Z
+```
+
+**Options:**
+
+- `--json` - Output as JSON
+- `--verbose` - Show additional details
+
+### `podctl oauth info`
+
+Get detailed information about an OAuth client.
+
+```bash
+podctl oauth info abc123xyz
+
+# Output:
+# Client ID: abc123xyz
+# Name: My Application
+# Redirect URIs: https://myapp.com/callback
+# Scope: openid offline pod:read pod:write
+# Grant Types: authorization_code, refresh_token
+# Created: 2024-01-15T10:30:00Z
+```
+
+**Arguments:**
+
+- `CLIENT_ID` - OAuth client ID
+
+### `podctl oauth delete`
+
+Delete an OAuth client.
+
+```bash
+podctl oauth delete abc123xyz
+
+# Confirmation prompt:
+# Delete OAuth client 'My Application'? (y/N): y
+# OAuth client deleted
+
+# Skip confirmation
+podctl oauth delete abc123xyz --force
+```
+
+**Arguments:**
+
+- `CLIENT_ID` - OAuth client ID
+
+**Options:**
+
+- `--force` - Skip confirmation
+
+## Rate Limit Commands
+
+### `podctl limit info`
+
+Get current rate limit information.
+
+```bash
+podctl limit info
+
+# Output:
+# Rate Limits:
+# Requests per minute: 60
+# Requests remaining: 45
+# Reset at: 2024-01-15T10:31:00Z
+# Max record size: 10MB
+# Max records per request: 1000
+# Pod creation per hour: 10
+# Pods created this hour: 2
+```
+
+**Options:**
+
+- `--json` - Output as JSON
+
 ## Global Options
 
 These options work with all commands:


### PR DESCRIPTION
- Remove emojis and promotional language from README.md
- Change 'Perfect for' to 'Suitable for'
- Replace 'What You Can Build' with 'Use Cases'
- Remove emojis from Key Features section
- Add missing CLI commands to docs/cli.md:
  - Link commands (set, list, remove)
  - OAuth client commands (register, list, info, delete)
  - Rate limit info command
- Ensure consistency between README and full CLI documentation