### PR TITLE
feat: Add performance testing improvements and query logging

### DIFF
--- a/node/packages/webpods-perf-tests/package.json
+++ b/node/packages/webpods-perf-tests/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "test": "LOG_LEVEL=error mocha --exit --timeout 120000",
+    "test:nocache": "WEBPODS_CONFIG_PATH=test-config-nocache.json LOG_LEVEL=warn mocha --exit --timeout 120000",
     "test:grep": "LOG_LEVEL=error mocha --exit --timeout 120000 --grep",
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",

--- a/node/packages/webpods-perf-tests/src/test-setup.ts
+++ b/node/packages/webpods-perf-tests/src/test-setup.ts
@@ -10,16 +10,21 @@ import { fileURLToPath } from "url";
 import { promises as fs } from "fs";
 import { PerfReport } from "./perf-utils.js";
 
+/* global before, after, afterEach */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Ensure test mode is enabled for this process
 process.env.NODE_ENV = "test";
 process.env.WEBPODS_TEST_MODE = "enabled";
 
-// Set config path for the test process itself (not just the server)
-process.env.WEBPODS_CONFIG_PATH = path.join(__dirname, "../test-config.json");
+// Test configuration - use env var if provided, otherwise default config
+const configFileName = process.env.WEBPODS_CONFIG_PATH || "test-config.json";
+const perfTestConfigPath = path.join(__dirname, "..", configFileName);
 
-// Test configuration
+// Set config path for the test process itself (not just the server)
+process.env.WEBPODS_CONFIG_PATH = perfTestConfigPath;
+
 export const testDb = new TestDatabase({
   dbName: "webpodsdb_test",
   logger: testLogger,
@@ -28,6 +33,7 @@ export const testServer = new TestServer({
   port: 3000,
   dbName: "webpodsdb_test",
   logger: testLogger,
+  configPath: perfTestConfigPath, // Use performance test config
 });
 
 // Global performance report
@@ -37,7 +43,23 @@ export const globalPerfReport = new PerfReport();
 before(async function () {
   this.timeout(60000); // 60 seconds for setup
 
-  console.log("\n🚀 Starting WebPods Performance Tests...\n");
+  testLogger.info("Starting WebPods Performance Tests");
+
+  // Read and display cache configuration only when disabled
+  try {
+    const configContent = await fs.readFile(perfTestConfigPath, "utf-8");
+    const config = JSON.parse(configContent);
+    const cacheEnabled = config.cache?.enabled || false;
+
+    // Only log when cache is disabled - use console.warn to ensure it shows
+    if (!cacheEnabled) {
+      // eslint-disable-next-line no-console
+      console.warn("\n⚠️  Cache Configuration: DISABLED\n");
+    }
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn("\n⚠️  Could not read cache configuration\n");
+  }
 
   // Clear test media directory
   const testMediaDir = path.join(process.cwd(), ".tests", "media");
@@ -75,7 +97,7 @@ after(async function () {
   );
   await fs.mkdir(path.dirname(summaryFile), { recursive: true });
   await fs.writeFile(summaryFile, globalPerfReport.getSummary(), "utf8");
-  console.log(`\nPerformance summary saved to: ${summaryFile}`);
+  testLogger.info(`Performance summary saved to: ${summaryFile}`);
 
   // Stop server
   await testServer.stop();

--- a/node/packages/webpods-perf-tests/test-config-nocache.json
+++ b/node/packages/webpods-perf-tests/test-config-nocache.json
@@ -46,7 +46,7 @@
     "publicUrl": "http://localhost:4444"
   },
   "cache": {
-    "enabled": true,
+    "enabled": false,
     "adapter": "in-memory",
     "pools": {
       "pods": {

--- a/node/packages/webpods-test-utils/src/utils/test-server.ts
+++ b/node/packages/webpods-test-utils/src/utils/test-server.ts
@@ -16,6 +16,7 @@ export interface TestServerConfig {
   logger?: Logger;
   useMockOAuth?: boolean;
   mockOAuthPort?: number;
+  configPath?: string; // Path to config.json file
 }
 
 export class TestServer {
@@ -31,6 +32,7 @@ export class TestServer {
       logger: config.logger,
       useMockOAuth: config.useMockOAuth !== false, // Default to true for tests
       mockOAuthPort: config.mockOAuthPort || 4567,
+      configPath: config.configPath, // Use provided config path
     };
     this.logger = config.logger || consoleLogger;
   }
@@ -44,11 +46,13 @@ export class TestServer {
 
     const serverPath = path.join(__dirname, "../../../webpods/dist/index.js");
 
-    // Path to test config file
-    const testConfigPath = path.join(
-      __dirname,
-      "../../../webpods-integration-tests/test-config.json",
-    );
+    // Path to test config file - use provided path or default to integration tests config
+    const testConfigPath =
+      this.config.configPath ||
+      path.join(
+        __dirname,
+        "../../../webpods-integration-tests/test-config.json",
+      );
 
     // Set environment variables (minimal now, config is in JSON)
     const env: any = {

--- a/node/packages/webpods/src/cache/types.ts
+++ b/node/packages/webpods/src/cache/types.ts
@@ -88,7 +88,7 @@ export const defaultCacheConfig: CacheConfig = {
     recordLists: {
       enabled: true,
       maxQueries: 500,
-      maxResultSizeBytes: 102400, // 100KB
+      maxResultSizeBytes: 52428800, // 50MB - for unique record lists
       maxRecordsPerQuery: 1000,
       ttlSeconds: 30, // 30 seconds
     },

--- a/node/packages/webpods/src/db/index.ts
+++ b/node/packages/webpods/src/db/index.ts
@@ -8,22 +8,89 @@ import { getConfig } from "../config-loader.js";
 
 const logger = createLogger("webpods:db");
 
-// Initialize pg-promise
-const pgp = pgPromise({
-  // Log queries in debug mode
-  query(e) {
-    if (process.env.LOG_LEVEL === "debug") {
-      logger.debug("Query", { query: e.query, params: e.params });
-    }
-  },
-  error(err, e) {
-    logger.error("Database error", {
-      error: err,
-      query: e?.query,
-      params: e?.params,
-    });
-  },
-});
+// Track query timings for query logging
+let queryCounter = 0;
+const queryTimings = new Map<number, number>();
+
+// Check if query logging is enabled
+const enableQueryLogging = process.env.WEBPODS_LOG_QUERIES === "true";
+if (enableQueryLogging) {
+  console.info("[SQL] Query logging enabled (WEBPODS_LOG_QUERIES=true)");
+}
+
+// Initialize pg-promise with conditional configuration
+const pgp = pgPromise(
+  enableQueryLogging
+    ? {
+        // With query logging
+        query(e) {
+          if (process.env.LOG_LEVEL === "debug") {
+            logger.debug("Query", { query: e.query, params: e.params });
+          }
+
+          // Assign a unique ID to this query
+          const queryId = ++queryCounter;
+          (e as any).__queryId = queryId;
+
+          // Store start time for this query
+          queryTimings.set(queryId, Date.now());
+
+          // Use console for direct output that bypasses log level restrictions
+          console.info(`\n[SQL QUERY #${queryId}]`, e.query);
+          if (e.params && Object.keys(e.params).length > 0) {
+            console.info(
+              `[SQL PARAMS #${queryId}]`,
+              JSON.stringify(e.params, null, 2),
+            );
+          }
+        },
+        receive(e) {
+          const rowCount =
+            e.result && "rows" in e.result ? e.result.rows.length : 0;
+
+          // Get the query ID from context
+          const queryId = (e.ctx as any).__queryId;
+          let duration = 0;
+
+          if (queryId && queryTimings.has(queryId)) {
+            duration = Date.now() - queryTimings.get(queryId)!;
+            queryTimings.delete(queryId);
+          }
+
+          console.info(
+            `[SQL RESULT #${queryId || "?"}] ${rowCount} rows in ${duration}ms`,
+          );
+
+          // Clean up old entries to prevent memory leak
+          if (queryTimings.size > 100) {
+            const oldestIds = Array.from(queryTimings.keys()).slice(0, 50);
+            oldestIds.forEach((id) => queryTimings.delete(id));
+          }
+        },
+        error(err, e) {
+          logger.error("Database error", {
+            error: err,
+            query: e?.query,
+            params: e?.params,
+          });
+        },
+      }
+    : {
+        // Without query logging
+        query(e) {
+          if (process.env.LOG_LEVEL === "debug") {
+            logger.debug("Query", { query: e.query, params: e.params });
+          }
+        },
+        error(err, e) {
+          logger.error("Database error", {
+            error: err,
+            query: e?.query,
+            params: e?.params,
+          });
+        },
+      },
+);
 
 // Database connection instance
 let db: pgPromise.IDatabase<unknown> | null = null;

--- a/node/packages/webpods/src/domain/records/list-unique-records.ts
+++ b/node/packages/webpods/src/domain/records/list-unique-records.ts
@@ -148,8 +148,9 @@ export async function listUniqueRecords(
       const resultSize = cache.checkSize(result);
       const cacheConfig = getCacheConfig();
       const ttl = cacheConfig?.pools?.recordLists?.ttlSeconds || 30;
-      if (resultSize <= 52428800) {
-        // 50MB limit for unique record lists
+      const maxSize =
+        cacheConfig?.pools?.recordLists?.maxResultSizeBytes || 102400; // Default 100KB
+      if (resultSize <= maxSize) {
         await cache.set("recordLists", cacheKey, result, ttl);
       }
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:integration": "cd node/packages/webpods-integration-tests && npm test",
     "test:cli": "cd node/packages/podctl-tests && npm test",
     "test:perf": "cd node/packages/webpods-perf-tests && npm test",
+    "test:perf:nocache": "cd node/packages/webpods-perf-tests && npm run test:nocache",
     "migrate:all": "./scripts/db-all.sh migrate:latest",
     "migrate:all:rollback": "./scripts/db-all.sh migrate:rollback",
     "migrate:all:status": "./scripts/db-all.sh migrate:status",


### PR DESCRIPTION
- Add configurable cache for performance tests with test:perf:nocache command
- Implement SQL query logging with WEBPODS_LOG_QUERIES=true environment variable
- Make cache maxResultSizeBytes configurable instead of hardcoded 50MB limit
- Fix TestServer to accept configPath parameter for test configurations
- Disable rate limits for performance tests (set to 1M)
- Add query timing and row count tracking for debugging

🤖 Generated with [Claude Code](https://claude.ai/code)