### PR TITLE
fix: Relay server output after startup in CLI test server

### DIFF
--- a/node/packages/podctl-tests/src/cli-test-server.ts
+++ b/node/packages/podctl-tests/src/cli-test-server.ts
@@ -61,6 +61,14 @@ export class CliTestServer {
           started = true;
           // Server is ready immediately after this message
           resolve();
+
+          // After startup, relay all server output to console for debugging
+          this.process!.stdout?.on("data", (data) => {
+            process.stdout.write(data);
+          });
+          this.process!.stderr?.on("data", (data) => {
+            process.stderr.write(data);
+          });
         }
       };
 


### PR DESCRIPTION
Modified CliTestServer to relay stdout and stderr output after server startup to ensure SQL query logs are visible when WEBPODS_LOG_QUERIES=true is set. Previously, output was only checked during startup but not relayed afterwards.

🤖 Generated with [Claude Code](https://claude.ai/code)