### PR TITLE
Remove unnecessary identity .select() statements from Tinqer queries

### DIFF
--- a/node/packages/webpods/src/api/oauth-clients.ts
+++ b/node/packages/webpods/src/api/oauth-clients.ts
@@ -256,8 +256,7 @@ router.get(
           q
             .from("oauth_client")
             .where((c) => c.user_id === p.user_id)
-            .orderByDescending((c) => c.created_at)
-            .select((c) => c),
+            .orderByDescending((c) => c.created_at),
         { user_id: userId },
       );
 
@@ -318,8 +317,7 @@ router.get(
             .where(
               (c) => c.client_id === p.client_id && c.user_id === p.user_id,
             )
-            .take(1)
-            .select((c) => c),
+            .take(1),
         { client_id: clientId || "", user_id: userId },
       );
 
@@ -389,8 +387,7 @@ router.delete(
             .where(
               (c) => c.client_id === p.client_id && c.user_id === p.user_id,
             )
-            .take(1)
-            .select((c) => c),
+            .take(1),
         { client_id: clientId || "", user_id: userId },
       );
 

--- a/node/packages/webpods/src/domain/permissions/can-read.ts
+++ b/node/packages/webpods/src/domain/permissions/can-read.ts
@@ -128,8 +128,7 @@ export async function canRead(
             .from("record")
             .where((r) => r.stream_id === p.stream_id && r.name === "owner")
             .orderByDescending((r) => r.index)
-            .take(1)
-            .select((r) => r),
+            .take(1),
         { stream_id: ownerStream.id },
       );
 
@@ -163,11 +162,7 @@ export async function canRead(
     const parentStreamResults = await executeSelect(
       ctx.db,
       schema,
-      (q, p) =>
-        q
-          .from("stream")
-          .where((s) => s.id === p.id)
-          .select((s) => s),
+      (q, p) => q.from("stream").where((s) => s.id === p.id),
       { id: currentStreamId },
     );
 

--- a/node/packages/webpods/src/domain/permissions/can-write.ts
+++ b/node/packages/webpods/src/domain/permissions/can-write.ts
@@ -125,8 +125,7 @@ export async function canWrite(
             .from("record")
             .where((r) => r.stream_id === p.stream_id && r.name === "owner")
             .orderByDescending((r) => r.index)
-            .take(1)
-            .select((r) => r),
+            .take(1),
         { stream_id: ownerStream.id },
       );
 
@@ -160,11 +159,7 @@ export async function canWrite(
     const parentStreamResults = await executeSelect(
       ctx.db,
       schema,
-      (q, p) =>
-        q
-          .from("stream")
-          .where((s) => s.id === p.id)
-          .select((s) => s),
+      (q, p) => q.from("stream").where((s) => s.id === p.id),
       { id: currentStreamId },
     );
 

--- a/node/packages/webpods/src/domain/permissions/check-permission-stream.ts
+++ b/node/packages/webpods/src/domain/permissions/check-permission-stream.ts
@@ -53,8 +53,7 @@ export async function checkPermissionStream(
         q
           .from("record")
           .where((r) => r.stream_id === p.streamId)
-          .orderBy((r) => r.index)
-          .select((r) => r),
+          .orderBy((r) => r.index),
       { streamId: stream.id },
     );
 

--- a/node/packages/webpods/src/domain/pods/get-pod-owner.ts
+++ b/node/packages/webpods/src/domain/pods/get-pod-owner.ts
@@ -101,8 +101,7 @@ export async function getPodOwner(
           .from("record")
           .where((r) => r.stream_id === p.streamId && r.name === "owner")
           .orderByDescending((r) => r.index)
-          .take(1)
-          .select((r) => r),
+          .take(1),
       { streamId: ownerStream.id },
     );
 

--- a/node/packages/webpods/src/domain/pods/get-pod.ts
+++ b/node/packages/webpods/src/domain/pods/get-pod.ts
@@ -51,11 +51,7 @@ export async function getPod(
     const pods = await executeSelect(
       ctx.db,
       schema,
-      (q, p) =>
-        q
-          .from("pod")
-          .where((pod) => pod.name === p.podName)
-          .select((pod) => pod),
+      (q, p) => q.from("pod").where((pod) => pod.name === p.podName),
       { podName },
     );
 

--- a/node/packages/webpods/src/domain/pods/list-pod-streams.ts
+++ b/node/packages/webpods/src/domain/pods/list-pod-streams.ts
@@ -195,11 +195,7 @@ export async function listPodStreams(
     const podResults = await executeSelect(
       ctx.db,
       schema,
-      (q, p) =>
-        q
-          .from("pod")
-          .where((pod) => pod.name === p.pod_name)
-          .select((pod) => pod),
+      (q, p) => q.from("pod").where((pod) => pod.name === p.pod_name),
       { pod_name: podName },
     );
 
@@ -218,8 +214,7 @@ export async function listPodStreams(
           .from("stream")
           .where((s) => s.pod_name === p.pod_name)
           .orderBy((s) => s.parent_id)
-          .thenBy((s) => s.name)
-          .select((s) => s),
+          .thenBy((s) => s.name),
       { pod_name: pod.name },
     );
 

--- a/node/packages/webpods/src/domain/pods/list-user-pods.ts
+++ b/node/packages/webpods/src/domain/pods/list-user-pods.ts
@@ -46,8 +46,7 @@ export async function listUserPods(
         q
           .from("pod")
           .where((pod) => pod.owner_id === p.ownerId)
-          .orderByDescending((pod) => pod.created_at)
-          .select((pod) => pod),
+          .orderByDescending((pod) => pod.created_at),
       { ownerId: userId },
     );
 

--- a/node/packages/webpods/src/domain/records/get-record-range.ts
+++ b/node/packages/webpods/src/domain/records/get-record-range.ts
@@ -97,8 +97,7 @@ export async function getRecordRange(
               r.index >= p.startIndex &&
               r.index < p.endIndex,
           )
-          .orderBy((r) => r.index)
-          .select((r) => r),
+          .orderBy((r) => r.index),
       {
         streamId,
         startIndex: actualStartIndex,

--- a/node/packages/webpods/src/domain/records/get-record.ts
+++ b/node/packages/webpods/src/domain/records/get-record.ts
@@ -76,8 +76,7 @@ export async function getRecord(
           .from("record")
           .where((r) => r.stream_id === p.streamId && r.name === p.name)
           .orderByDescending((r) => r.index)
-          .take(1)
-          .select((r) => r),
+          .take(1),
       { streamId, name },
     );
 

--- a/node/packages/webpods/src/domain/records/list-records-recursive.ts
+++ b/node/packages/webpods/src/domain/records/list-records-recursive.ts
@@ -128,8 +128,7 @@ export async function listRecordsRecursive(
                 .where((r) => p.streamIds.includes(r.stream_id))
                 .orderBy((r) => r.created_at)
                 .skip(p.offset)
-                .take(p.limit)
-                .select((r) => r),
+                .take(p.limit),
             {
               streamIds: readableStreamIds,
               offset: actualAfter,
@@ -144,8 +143,7 @@ export async function listRecordsRecursive(
                 .from("record")
                 .where((r) => p.streamIds.includes(r.stream_id))
                 .orderBy((r) => r.created_at)
-                .take(p.limit)
-                .select((r) => r),
+                .take(p.limit),
             { streamIds: readableStreamIds, limit: limit + 1 },
           );
 

--- a/node/packages/webpods/src/domain/records/list-records.ts
+++ b/node/packages/webpods/src/domain/records/list-records.ts
@@ -133,8 +133,7 @@ export async function listRecords(
                 .from("record")
                 .where((r) => r.stream_id === p.streamId && r.index > p.after)
                 .orderBy((r) => r.index)
-                .take(p.limit)
-                .select((r) => r),
+                .take(p.limit),
             { streamId, after: actualAfter, limit: limit + 1 },
           )
         : await executeSelect(
@@ -145,8 +144,7 @@ export async function listRecords(
                 .from("record")
                 .where((r) => r.stream_id === p.streamId)
                 .orderBy((r) => r.index)
-                .take(p.limit)
-                .select((r) => r),
+                .take(p.limit),
             { streamId, limit: limit + 1 },
           );
 

--- a/node/packages/webpods/src/domain/records/list-unique-records.ts
+++ b/node/packages/webpods/src/domain/records/list-unique-records.ts
@@ -115,8 +115,7 @@ export async function listUniqueRecords(
               .orderByDescending((row) => row.index)
               .rowNumber(),
           }))
-          .where((r) => r.rn === 1)
-          .select((r) => r),
+          .where((r) => r.rn === 1),
       { streamId },
     );
 

--- a/node/packages/webpods/src/domain/resolution/resolve-path.ts
+++ b/node/packages/webpods/src/domain/resolution/resolve-path.ts
@@ -64,8 +64,7 @@ export async function resolvePath(
         (q, p) =>
           q
             .from("stream")
-            .where((s) => s.pod_name === p.podName && s.path === p.path)
-            .select((s) => s),
+            .where((s) => s.pod_name === p.podName && s.path === p.path),
         { podName, path: normalizedPath },
       );
 
@@ -91,8 +90,7 @@ export async function resolvePath(
       (q, p) =>
         q
           .from("stream")
-          .where((s) => s.pod_name === p.podName && s.path === p.path)
-          .select((s) => s),
+          .where((s) => s.pod_name === p.podName && s.path === p.path),
       { podName, path: normalizedPath },
     );
 
@@ -188,8 +186,7 @@ export async function resolvePathForWrite(
         (q, p) =>
           q
             .from("stream")
-            .where((s) => s.pod_name === p.podName && s.path === p.path)
-            .select((s) => s),
+            .where((s) => s.pod_name === p.podName && s.path === p.path),
         { podName, path: "/" },
       );
 
@@ -217,8 +214,7 @@ export async function resolvePathForWrite(
       (q, p) =>
         q
           .from("stream")
-          .where((s) => s.pod_name === p.podName && s.path === p.path)
-          .select((s) => s),
+          .where((s) => s.pod_name === p.podName && s.path === p.path),
       { podName, path: streamPath },
     );
 

--- a/node/packages/webpods/src/domain/routing/find-pod-by-domain.ts
+++ b/node/packages/webpods/src/domain/routing/find-pod-by-domain.ts
@@ -33,12 +33,7 @@ export async function findPodByDomain(
     }
 
     // Get all pods using Tinqer
-    const pods = await executeSelect(
-      ctx.db,
-      schema,
-      (q) => q.from("pod").select((p) => p),
-      {},
-    );
+    const pods = await executeSelect(ctx.db, schema, (q) => q.from("pod"), {});
 
     // Check each pod's domains
     for (const pod of pods) {
@@ -85,8 +80,7 @@ export async function findPodByDomain(
           q
             .from("record")
             .where((r) => r.stream_id === p.streamId)
-            .orderBy((r) => r.index)
-            .select((r) => r),
+            .orderBy((r) => r.index),
         { streamId: domainsStream.id },
       );
 

--- a/node/packages/webpods/src/domain/routing/resolve-link.ts
+++ b/node/packages/webpods/src/domain/routing/resolve-link.ts
@@ -85,8 +85,7 @@ export async function resolveLink(
           .from("record")
           .where((r) => r.stream_id === p.stream_id && r.name === "routes")
           .orderByDescending((r) => r.created_at)
-          .take(1)
-          .select((r) => r),
+          .take(1),
       { stream_id: routingStream.id },
     );
 
@@ -102,8 +101,7 @@ export async function resolveLink(
             .from("record")
             .where((r) => r.stream_id === p.stream_id && r.name === null)
             .orderByDescending((r) => r.created_at)
-            .take(1)
-            .select((r) => r),
+            .take(1),
         { stream_id: routingStream.id },
       );
       record = unnamedResults[0] || null;

--- a/node/packages/webpods/src/domain/streams/create-stream-hierarchy.ts
+++ b/node/packages/webpods/src/domain/streams/create-stream-hierarchy.ts
@@ -51,8 +51,7 @@ export async function createStreamHierarchy(
               s.pod_name === p.podName &&
               s.name === p.name &&
               s.parent_id === null,
-          )
-          .select((s) => s),
+          ),
       { podName, name: "/" },
     );
 

--- a/node/packages/webpods/src/domain/streams/create-stream.ts
+++ b/node/packages/webpods/src/domain/streams/create-stream.ts
@@ -67,8 +67,7 @@ export async function createStream(
               s.pod_name === p.podName &&
               s.name === p.name &&
               s.parent_id === p.parentId,
-          )
-          .select((s) => s),
+          ),
       { podName, name: streamName, parentId },
     );
 
@@ -89,8 +88,7 @@ export async function createStream(
           q
             .from("record")
             .where((r) => r.stream_id === p.parentId && r.name === p.name)
-            .take(1)
-            .select((r) => r),
+            .take(1),
         { parentId, name: streamName },
       );
 
@@ -130,8 +128,7 @@ export async function createStream(
             .from("record")
             .where((r) => r.stream_id === p.streamId && r.name === "owner")
             .orderByDescending((r) => r.index)
-            .take(1)
-            .select((r) => r),
+            .take(1),
         { streamId: ownerStream.id },
       );
 

--- a/node/packages/webpods/src/domain/streams/get-stream-by-id.ts
+++ b/node/packages/webpods/src/domain/streams/get-stream-by-id.ts
@@ -58,11 +58,7 @@ export async function getStreamById(
     const streams = await executeSelect(
       ctx.db,
       schema,
-      (q, p) =>
-        q
-          .from("stream")
-          .where((s) => s.id === p.id)
-          .select((s) => s),
+      (q, p) => q.from("stream").where((s) => s.id === p.id),
       { id: streamId },
     );
 

--- a/node/packages/webpods/src/domain/streams/get-stream-by-path.ts
+++ b/node/packages/webpods/src/domain/streams/get-stream-by-path.ts
@@ -78,8 +78,7 @@ export async function getStreamByPath(
       (q, p) =>
         q
           .from("stream")
-          .where((s) => s.pod_name === p.podName && s.path === p.path)
-          .select((s) => s),
+          .where((s) => s.pod_name === p.podName && s.path === p.path),
       { podName, path: normalizedPath },
     );
 

--- a/node/packages/webpods/src/domain/streams/get-streams-with-prefix.ts
+++ b/node/packages/webpods/src/domain/streams/get-streams-with-prefix.ts
@@ -60,8 +60,7 @@ export async function getStreamsWithPrefix(
               s.pod_name === p.podName &&
               (s.path === p.streamPath || s.path.startsWith(p.pathPattern)),
           )
-          .orderBy((s) => s.path)
-          .select((s) => s),
+          .orderBy((s) => s.path),
       { podName, streamPath, pathPattern },
     );
 

--- a/node/packages/webpods/src/domain/streams/list-child-streams.ts
+++ b/node/packages/webpods/src/domain/streams/list-child-streams.ts
@@ -68,8 +68,7 @@ export async function listChildStreams(
               .where(
                 (s) => s.pod_name === p.podName && s.parent_id === p.parentId,
               )
-              .orderBy((s) => s.name)
-              .select((s) => s),
+              .orderBy((s) => s.name),
           { podName, parentId },
         )
       : await executeSelect(
@@ -79,8 +78,7 @@ export async function listChildStreams(
             q
               .from("stream")
               .where((s) => s.pod_name === p.podName && s.parent_id === null)
-              .orderBy((s) => s.name)
-              .select((s) => s),
+              .orderBy((s) => s.name),
           { podName },
         );
 

--- a/node/packages/webpods/src/domain/users/ensure-user-exists.ts
+++ b/node/packages/webpods/src/domain/users/ensure-user-exists.ts
@@ -34,11 +34,7 @@ export async function ensureUserExists(
     const existingUsers = await executeSelect(
       ctx.db,
       schema,
-      (q, p) =>
-        q
-          .from("user")
-          .where((u) => u.id === p.user_id)
-          .select((u) => u),
+      (q, p) => q.from("user").where((u) => u.id === p.user_id),
       { user_id: userId },
     );
 

--- a/node/packages/webpods/src/domain/users/find-or-create-user.ts
+++ b/node/packages/webpods/src/domain/users/find-or-create-user.ts
@@ -64,8 +64,7 @@ export async function findOrCreateUser(
           .from("identity")
           .where(
             (i) => i.provider === p.provider && i.provider_id === p.provider_id,
-          )
-          .select((i) => i),
+          ),
       { provider: provider.provider, provider_id: providerId },
     );
 
@@ -78,11 +77,7 @@ export async function findOrCreateUser(
       const userRows = await executeSelect(
         ctx.db,
         schema,
-        (q, p) =>
-          q
-            .from("user")
-            .where((u) => u.id === p.user_id)
-            .select((u) => u),
+        (q, p) => q.from("user").where((u) => u.id === p.user_id),
         { user_id: existingIdentity.userId },
       );
 

--- a/node/packages/webpods/src/oauth/connect.ts
+++ b/node/packages/webpods/src/oauth/connect.ts
@@ -48,11 +48,7 @@ router.get("/", rateLimit("read"), async (req: Request, res: Response) => {
     const clients = await executeSelect(
       db,
       schema,
-      (q, p) =>
-        q
-          .from("oauth_client")
-          .where((c) => c.client_id === p.clientId)
-          .select((c) => c),
+      (q, p) => q.from("oauth_client").where((c) => c.client_id === p.clientId),
       { clientId },
     );
 


### PR DESCRIPTION
Tinqer returns all columns by default when .select() is omitted, making identity selects like `.select((x) => x)` redundant.

Removed from 25 files across domain, api, and oauth modules. All tests passing (370 integration + CLI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)